### PR TITLE
Auth API 전체 구현 (SMS 인증, 로그인, 회원가입, 토큰 관리)

### DIFF
--- a/src/main/java/com/guegue/duty_checker/auth/dto/RegisterRespDto.java
+++ b/src/main/java/com/guegue/duty_checker/auth/dto/RegisterRespDto.java
@@ -6,15 +6,13 @@ import lombok.Getter;
 
 @Getter
 public class RegisterRespDto {
-    private final String accessToken;
-    private final String refreshToken;
-    private final UserInfo user;
+    private final Long id;
+    private final String phone;
+    private final Role role;
 
-    public RegisterRespDto(String accessToken, String refreshToken, User user) {
-        this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
-        this.user = new UserInfo(user.getId(), user.getPhone(), user.getRole());
+    public RegisterRespDto(User user) {
+        this.id = user.getId();
+        this.phone = user.getPhone();
+        this.role = user.getRole();
     }
-
-    public record UserInfo(Long id, String phone, Role role) {}
 }

--- a/src/main/java/com/guegue/duty_checker/auth/service/AuthService.java
+++ b/src/main/java/com/guegue/duty_checker/auth/service/AuthService.java
@@ -85,11 +85,7 @@ public class AuthService {
         userRepository.save(user);
         verifiedPhoneRedisRepository.delete(phone);
 
-        String accessToken = jwtProvider.generateAccessToken(phone);
-        String refreshToken = jwtProvider.generateRefreshToken(phone);
-        refreshTokenRedisRepository.save(refreshToken, phone);
-
-        return new RegisterRespDto(accessToken, refreshToken, user);
+        return new RegisterRespDto(user);
     }
 
     public LoginRespDto login(LoginReqDto reqDto) {


### PR DESCRIPTION
## Summary

- SMS 인증코드 발송/검증 구현 (`POST /auth/send-code`, `POST /auth/verify-code`)
- 회원가입 구현 (`POST /auth/register`) — 토큰 미발급, login으로 일원화
- 로그인/로그아웃/토큰 리프레시 구현 (`POST /auth/login`, `POST /auth/logout`, `POST /auth/refresh`)
- JWT 인증, Redis 기반 SMS 코드/verifiedPhone/refreshToken 저장

## 관련 이슈

Closes #6, Closes #7, Closes #8, Closes #9, Closes #14, Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)