### PR TITLE
#34 AuthService 도메인 경계 위반 리팩토링 (UserRepository → UserService 경유)

### DIFF
--- a/src/main/java/com/guegue/duty_checker/auth/service/AuthService.java
+++ b/src/main/java/com/guegue/duty_checker/auth/service/AuthService.java
@@ -9,7 +9,6 @@ import com.guegue.duty_checker.common.config.JwtProvider;
 import com.guegue.duty_checker.common.exception.BusinessException;
 import com.guegue.duty_checker.common.exception.ErrorCode;
 import com.guegue.duty_checker.user.domain.User;
-import com.guegue.duty_checker.user.repository.UserRepository;
 import com.guegue.duty_checker.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -30,7 +29,6 @@ public class AuthService {
     private final RefreshTokenRedisRepository refreshTokenRedisRepository;
     private final SmsProvider smsProvider;
     private final JwtProvider jwtProvider;
-    private final UserRepository userRepository;
     private final UserService userService;
     private final PasswordEncoder passwordEncoder;
 
@@ -75,7 +73,7 @@ public class AuthService {
             throw new BusinessException(ErrorCode.PHONE_NOT_VERIFIED);
         }
 
-        if (userRepository.existsByPhone(phone)) {
+        if (userService.existsByPhone(phone)) {
             throw new BusinessException(ErrorCode.ALREADY_REGISTERED);
         }
 
@@ -84,7 +82,7 @@ public class AuthService {
                 .password(passwordEncoder.encode(reqDto.getPassword()))
                 .role(reqDto.getRole())
                 .build();
-        userRepository.save(user);
+        userService.save(user);
         verifiedPhoneRedisRepository.delete(phone);
 
         return new RegisterRespDto(user);
@@ -93,8 +91,7 @@ public class AuthService {
     public LoginRespDto login(LoginReqDto reqDto) {
         String phone = reqDto.getPhone();
 
-        User user = userRepository.findByPhone(phone)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND, "가입되지 않은 전화번호입니다"));
+        User user = userService.getByPhone(phone);
 
         if (!passwordEncoder.matches(reqDto.getPassword(), user.getPassword())) {
             throw new BusinessException(ErrorCode.INVALID_PASSWORD);

--- a/src/main/java/com/guegue/duty_checker/user/service/UserService.java
+++ b/src/main/java/com/guegue/duty_checker/user/service/UserService.java
@@ -20,6 +20,16 @@ public class UserService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 
+    @Transactional(readOnly = true)
+    public boolean existsByPhone(String phone) {
+        return userRepository.existsByPhone(phone);
+    }
+
+    @Transactional
+    public User save(User user) {
+        return userRepository.save(user);
+    }
+
     @Transactional
     public void updateFcmToken(String phone, String fcmToken) {
         getByPhone(phone).updateFcmToken(fcmToken);


### PR DESCRIPTION
## Summary

- `AuthService`에서 `UserRepository` 직접 의존 제거
- `UserService`를 통해 User 조회/저장/중복확인 처리
- `UserService`에 `existsByPhone()`, `save()` 메서드 추가

## 변경 파일

- `AuthService` — `UserRepository` 제거, `UserService` 경유로 전환
- `UserService` — `existsByPhone()`, `save()` 추가

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)