### PR TITLE
#33 PENDING→CONNECTED 자동 전환 구현

### DIFF
--- a/src/main/java/com/guegue/duty_checker/auth/service/AuthService.java
+++ b/src/main/java/com/guegue/duty_checker/auth/service/AuthService.java
@@ -8,6 +8,7 @@ import com.guegue.duty_checker.auth.infrastructure.VerifiedPhoneRedisRepository;
 import com.guegue.duty_checker.common.config.JwtProvider;
 import com.guegue.duty_checker.common.exception.BusinessException;
 import com.guegue.duty_checker.common.exception.ErrorCode;
+import com.guegue.duty_checker.connection.service.ConnectionService;
 import com.guegue.duty_checker.user.domain.User;
 import com.guegue.duty_checker.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,7 @@ public class AuthService {
     private final SmsProvider smsProvider;
     private final JwtProvider jwtProvider;
     private final UserService userService;
+    private final ConnectionService connectionService;
     private final PasswordEncoder passwordEncoder;
 
     public SendCodeRespDto sendCode(SendCodeReqDto reqDto) {
@@ -84,6 +86,7 @@ public class AuthService {
                 .build();
         userService.save(user);
         verifiedPhoneRedisRepository.delete(phone);
+        connectionService.activatePendingConnections(phone, user);
 
         return new RegisterRespDto(user);
     }

--- a/src/main/java/com/guegue/duty_checker/connection/repository/ConnectionRepository.java
+++ b/src/main/java/com/guegue/duty_checker/connection/repository/ConnectionRepository.java
@@ -18,4 +18,5 @@ public interface ConnectionRepository extends JpaRepository<Connection, Long> {
 
     long countBySubject(User subject);
 
+    List<Connection> findByGuardianPhoneAndStatus(String guardianPhone, com.guegue.duty_checker.connection.domain.ConnectionStatus status);
 }

--- a/src/main/java/com/guegue/duty_checker/connection/service/ConnectionService.java
+++ b/src/main/java/com/guegue/duty_checker/connection/service/ConnectionService.java
@@ -61,6 +61,12 @@ public class ConnectionService {
         return new AddConnectionRespDto(connection);
     }
 
+    @Transactional
+    public void activatePendingConnections(String guardianPhone, User guardian) {
+        List<Connection> pending = connectionRepository.findByGuardianPhoneAndStatus(guardianPhone, ConnectionStatus.PENDING);
+        pending.forEach(c -> c.connectGuardian(guardian));
+    }
+
     @Transactional(readOnly = true)
     public GetConnectionsRespDto getConnections(String phone) {
         User user = userService.getByPhone(phone);


### PR DESCRIPTION
## Summary

- 보호자가 `POST /auth/register`로 회원가입 시, 자신의 전화번호로 등록된 `PENDING` 상태 연결을 `CONNECTED`로 자동 전환
- `ConnectionService.activatePendingConnections()` 추가
- `ConnectionRepository.findByGuardianPhoneAndStatus()` 쿼리 추가
- `AuthService.register()` 완료 후 `activatePendingConnections()` 호출

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)