### PR TITLE
#40 Service 단위 테스트 작성

### DIFF
--- a/src/test/java/com/guegue/duty_checker/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/guegue/duty_checker/auth/service/AuthServiceTest.java
@@ -1,0 +1,236 @@
+package com.guegue.duty_checker.auth.service;
+
+import com.guegue.duty_checker.auth.dto.*;
+import com.guegue.duty_checker.auth.infrastructure.*;
+import com.guegue.duty_checker.common.config.JwtProvider;
+import com.guegue.duty_checker.common.exception.BusinessException;
+import com.guegue.duty_checker.common.exception.ErrorCode;
+import com.guegue.duty_checker.connection.service.ConnectionService;
+import com.guegue.duty_checker.user.domain.Role;
+import com.guegue.duty_checker.user.domain.User;
+import com.guegue.duty_checker.user.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @InjectMocks AuthService authService;
+
+    @Mock SmsCodeRedisRepository smsCodeRedisRepository;
+    @Mock VerifiedPhoneRedisRepository verifiedPhoneRedisRepository;
+    @Mock RefreshTokenRedisRepository refreshTokenRedisRepository;
+    @Mock SmsProvider smsProvider;
+    @Mock JwtProvider jwtProvider;
+    @Mock UserService userService;
+    @Mock ConnectionService connectionService;
+    @Mock PasswordEncoder passwordEncoder;
+
+    private SendCodeReqDto sendCodeReq(String phone) {
+        SendCodeReqDto dto = new SendCodeReqDto();
+        ReflectionTestUtils.setField(dto, "phone", phone);
+        return dto;
+    }
+
+    private VerifyCodeReqDto verifyCodeReq(String phone, String code) {
+        VerifyCodeReqDto dto = new VerifyCodeReqDto();
+        ReflectionTestUtils.setField(dto, "phone", phone);
+        ReflectionTestUtils.setField(dto, "verificationCode", code);
+        return dto;
+    }
+
+    private RegisterReqDto registerReq(String phone, String password, Role role) {
+        RegisterReqDto dto = new RegisterReqDto();
+        ReflectionTestUtils.setField(dto, "phone", phone);
+        ReflectionTestUtils.setField(dto, "password", password);
+        ReflectionTestUtils.setField(dto, "role", role);
+        return dto;
+    }
+
+    private LoginReqDto loginReq(String phone, String password) {
+        LoginReqDto dto = new LoginReqDto();
+        ReflectionTestUtils.setField(dto, "phone", phone);
+        ReflectionTestUtils.setField(dto, "password", password);
+        return dto;
+    }
+
+    private User user(String phone, Role role) {
+        return User.builder().phone(phone).password("encoded").role(role).build();
+    }
+
+    // ─── sendCode ──────────────────────────────────────────────────────────
+
+    @Test
+    void sendCode_쿨다운중_예외발생() {
+        given(smsCodeRedisRepository.isOnCooldown("01011111111")).willReturn(true);
+        given(smsCodeRedisRepository.getRemainingCooldownSeconds("01011111111")).willReturn(30L);
+
+        assertThatThrownBy(() -> authService.sendCode(sendCodeReq("01011111111")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_SEND_CODE_COOLDOWN);
+    }
+
+    @Test
+    void sendCode_정상_코드저장및SMS발송() {
+        given(smsCodeRedisRepository.isOnCooldown("01011111111")).willReturn(false);
+
+        SendCodeRespDto resp = authService.sendCode(sendCodeReq("01011111111"));
+
+        verify(smsCodeRedisRepository).saveCode(eq("01011111111"), anyString());
+        verify(smsProvider).send(eq("01011111111"), anyString());
+        assertThat(resp.getExpiredAt()).isNotNull();
+    }
+
+    // ─── verifyCode ────────────────────────────────────────────────────────
+
+    @Test
+    void verifyCode_코드만료_예외발생() {
+        given(smsCodeRedisRepository.findCode("01011111111")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.verifyCode(verifyCodeReq("01011111111", "123456")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_CODE_EXPIRED);
+    }
+
+    @Test
+    void verifyCode_코드불일치_횟수미초과_예외발생() {
+        given(smsCodeRedisRepository.findCode("01011111111")).willReturn(Optional.of("111111"));
+        given(smsCodeRedisRepository.incrementAttemptsAndCheckExceeded("01011111111")).willReturn(false);
+
+        assertThatThrownBy(() -> authService.verifyCode(verifyCodeReq("01011111111", "999999")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_CODE_MISMATCH);
+    }
+
+    @Test
+    void verifyCode_코드불일치_횟수초과_예외발생() {
+        given(smsCodeRedisRepository.findCode("01011111111")).willReturn(Optional.of("111111"));
+        given(smsCodeRedisRepository.incrementAttemptsAndCheckExceeded("01011111111")).willReturn(true);
+
+        assertThatThrownBy(() -> authService.verifyCode(verifyCodeReq("01011111111", "999999")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_CODE_ATTEMPTS_EXCEEDED);
+    }
+
+    @Test
+    void verifyCode_코드일치_인증저장() {
+        given(smsCodeRedisRepository.findCode("01011111111")).willReturn(Optional.of("123456"));
+
+        authService.verifyCode(verifyCodeReq("01011111111", "123456"));
+
+        verify(smsCodeRedisRepository).deleteCode("01011111111");
+        verify(verifiedPhoneRedisRepository).save("01011111111");
+    }
+
+    // ─── register ──────────────────────────────────────────────────────────
+
+    @Test
+    void register_전화번호미인증_예외발생() {
+        given(verifiedPhoneRedisRepository.isVerified("01011111111")).willReturn(false);
+
+        assertThatThrownBy(() -> authService.register(registerReq("01011111111", "pw", Role.SUBJECT)))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.PHONE_NOT_VERIFIED);
+    }
+
+    @Test
+    void register_이미가입된번호_예외발생() {
+        given(verifiedPhoneRedisRepository.isVerified("01011111111")).willReturn(true);
+        given(userService.existsByPhone("01011111111")).willReturn(true);
+
+        assertThatThrownBy(() -> authService.register(registerReq("01011111111", "pw", Role.SUBJECT)))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ALREADY_REGISTERED);
+    }
+
+    @Test
+    void register_정상_유저저장및PENDING활성화() {
+        given(verifiedPhoneRedisRepository.isVerified("01011111111")).willReturn(true);
+        given(userService.existsByPhone("01011111111")).willReturn(false);
+        given(passwordEncoder.encode("pw")).willReturn("encoded");
+
+        RegisterRespDto resp = authService.register(registerReq("01011111111", "pw", Role.SUBJECT));
+
+        verify(userService).save(any(User.class));
+        verify(verifiedPhoneRedisRepository).delete("01011111111");
+        verify(connectionService).activatePendingConnections(eq("01011111111"), any(User.class));
+        assertThat(resp).isNotNull();
+    }
+
+    // ─── login ─────────────────────────────────────────────────────────────
+
+    @Test
+    void login_비밀번호불일치_예외발생() {
+        User u = user("01011111111", Role.SUBJECT);
+        given(userService.getByPhone("01011111111")).willReturn(u);
+        given(passwordEncoder.matches("wrong", "encoded")).willReturn(false);
+
+        assertThatThrownBy(() -> authService.login(loginReq("01011111111", "wrong")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_PASSWORD);
+    }
+
+    @Test
+    void login_정상_토큰발급() {
+        User u = user("01011111111", Role.SUBJECT);
+        given(userService.getByPhone("01011111111")).willReturn(u);
+        given(passwordEncoder.matches("pw", "encoded")).willReturn(true);
+        given(jwtProvider.generateAccessToken("01011111111")).willReturn("access");
+        given(jwtProvider.generateRefreshToken("01011111111")).willReturn("refresh");
+
+        LoginRespDto resp = authService.login(loginReq("01011111111", "pw"));
+
+        assertThat(resp.getAccessToken()).isEqualTo("access");
+        assertThat(resp.getRefreshToken()).isEqualTo("refresh");
+        verify(refreshTokenRedisRepository).save("refresh", "01011111111");
+    }
+
+    // ─── refresh ───────────────────────────────────────────────────────────
+
+    @Test
+    void refresh_유효하지않은토큰_예외발생() {
+        RefreshTokenReqDto dto = new RefreshTokenReqDto();
+        ReflectionTestUtils.setField(dto, "refreshToken", "invalid");
+        given(refreshTokenRedisRepository.findPhoneByToken("invalid")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.refresh(dto))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    @Test
+    void refresh_정상_새토큰발급() {
+        RefreshTokenReqDto dto = new RefreshTokenReqDto();
+        ReflectionTestUtils.setField(dto, "refreshToken", "old-refresh");
+        given(refreshTokenRedisRepository.findPhoneByToken("old-refresh")).willReturn(Optional.of("01011111111"));
+        given(jwtProvider.generateAccessToken("01011111111")).willReturn("new-access");
+        given(jwtProvider.generateRefreshToken("01011111111")).willReturn("new-refresh");
+
+        RefreshTokenRespDto resp = authService.refresh(dto);
+
+        verify(refreshTokenRedisRepository).deleteByToken("old-refresh");
+        assertThat(resp.getAccessToken()).isEqualTo("new-access");
+        assertThat(resp.getRefreshToken()).isEqualTo("new-refresh");
+    }
+}

--- a/src/test/java/com/guegue/duty_checker/checkin/service/CheckInServiceTest.java
+++ b/src/test/java/com/guegue/duty_checker/checkin/service/CheckInServiceTest.java
@@ -1,0 +1,131 @@
+package com.guegue.duty_checker.checkin.service;
+
+import com.guegue.duty_checker.checkin.domain.CheckIn;
+import com.guegue.duty_checker.checkin.repository.CheckInRepository;
+import com.guegue.duty_checker.common.exception.BusinessException;
+import com.guegue.duty_checker.common.exception.ErrorCode;
+import com.guegue.duty_checker.user.domain.Role;
+import com.guegue.duty_checker.user.domain.User;
+import com.guegue.duty_checker.user.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CheckInServiceTest {
+
+    @InjectMocks CheckInService checkInService;
+
+    @Mock CheckInRepository checkInRepository;
+    @Mock UserService userService;
+
+    private User user(String phone, Role role) {
+        return User.builder().phone(phone).password("pw").role(role).build();
+    }
+
+    private CheckIn checkInAt(User user, ZonedDateTime time) {
+        CheckIn ci = CheckIn.builder().subject(user).checkedAt(time).build();
+        return ci;
+    }
+
+    // ─── createCheckIn ─────────────────────────────────────────────────────
+
+    @Test
+    void createCheckIn_보호자역할_예외발생() {
+        User guardian = user("01022222222", Role.GUARDIAN);
+        given(userService.getByPhone("01022222222")).willReturn(guardian);
+
+        assertThatThrownBy(() -> checkInService.createCheckIn("01022222222"))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CHECK_IN_FORBIDDEN);
+    }
+
+    @Test
+    void createCheckIn_오늘이미체크인_예외발생() {
+        User subject = user("01011111111", Role.SUBJECT);
+        given(userService.getByPhone("01011111111")).willReturn(subject);
+        given(checkInRepository.existsBySubjectAndCheckedAtBetween(eq(subject), any(), any())).willReturn(true);
+
+        assertThatThrownBy(() -> checkInService.createCheckIn("01011111111"))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ALREADY_CHECKED_IN);
+    }
+
+    @Test
+    void createCheckIn_정상_체크인저장() {
+        User subject = user("01011111111", Role.SUBJECT);
+        given(userService.getByPhone("01011111111")).willReturn(subject);
+        given(checkInRepository.existsBySubjectAndCheckedAtBetween(eq(subject), any(), any())).willReturn(false);
+
+        var resp = checkInService.createCheckIn("01011111111");
+
+        verify(checkInRepository).save(any(CheckIn.class));
+        assertThat(resp.getCheckedAt()).isNotNull();
+    }
+
+    // ─── getLatestCheckIn ──────────────────────────────────────────────────
+
+    @Test
+    void getLatestCheckIn_보호자역할_예외발생() {
+        User guardian = user("01022222222", Role.GUARDIAN);
+        given(userService.getByPhone("01022222222")).willReturn(guardian);
+
+        assertThatThrownBy(() -> checkInService.getLatestCheckIn("01022222222"))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CHECK_IN_FORBIDDEN);
+    }
+
+    @Test
+    void getLatestCheckIn_체크인없음_false반환() {
+        User subject = user("01011111111", Role.SUBJECT);
+        given(userService.getByPhone("01011111111")).willReturn(subject);
+        given(checkInRepository.findTopBySubjectOrderByCheckedAtDesc(subject)).willReturn(Optional.empty());
+
+        var resp = checkInService.getLatestCheckIn("01011111111");
+
+        assertThat(resp.getLatestCheckedAt()).isNull();
+        assertThat(resp.isTodayChecked()).isFalse();
+    }
+
+    @Test
+    void getLatestCheckIn_오늘체크인_true반환() {
+        User subject = user("01011111111", Role.SUBJECT);
+        ZonedDateTime now = ZonedDateTime.now();
+        CheckIn ci = checkInAt(subject, now);
+        given(userService.getByPhone("01011111111")).willReturn(subject);
+        given(checkInRepository.findTopBySubjectOrderByCheckedAtDesc(subject)).willReturn(Optional.of(ci));
+
+        var resp = checkInService.getLatestCheckIn("01011111111");
+
+        assertThat(resp.isTodayChecked()).isTrue();
+    }
+
+    @Test
+    void getLatestCheckIn_어제체크인_false반환() {
+        User subject = user("01011111111", Role.SUBJECT);
+        ZonedDateTime yesterday = ZonedDateTime.now().minusDays(1);
+        CheckIn ci = checkInAt(subject, yesterday);
+        given(userService.getByPhone("01011111111")).willReturn(subject);
+        given(checkInRepository.findTopBySubjectOrderByCheckedAtDesc(subject)).willReturn(Optional.of(ci));
+
+        var resp = checkInService.getLatestCheckIn("01011111111");
+
+        assertThat(resp.isTodayChecked()).isFalse();
+    }
+}

--- a/src/test/java/com/guegue/duty_checker/connection/service/ConnectionServiceTest.java
+++ b/src/test/java/com/guegue/duty_checker/connection/service/ConnectionServiceTest.java
@@ -1,0 +1,241 @@
+package com.guegue.duty_checker.connection.service;
+
+import com.guegue.duty_checker.checkin.service.CheckInService;
+import com.guegue.duty_checker.checkin.dto.GetLatestCheckInRespDto;
+import com.guegue.duty_checker.common.exception.BusinessException;
+import com.guegue.duty_checker.common.exception.ErrorCode;
+import com.guegue.duty_checker.connection.domain.Connection;
+import com.guegue.duty_checker.connection.domain.ConnectionStatus;
+import com.guegue.duty_checker.connection.dto.AddConnectionReqDto;
+import com.guegue.duty_checker.connection.dto.UpdateConnectionNameReqDto;
+import com.guegue.duty_checker.connection.repository.ConnectionRepository;
+import com.guegue.duty_checker.user.domain.Role;
+import com.guegue.duty_checker.user.domain.User;
+import com.guegue.duty_checker.user.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ConnectionServiceTest {
+
+    @InjectMocks ConnectionService connectionService;
+
+    @Mock ConnectionRepository connectionRepository;
+    @Mock UserService userService;
+    @Mock CheckInService checkInService;
+
+    private User user(String phone, Role role) {
+        return User.builder().phone(phone).password("pw").role(role).build();
+    }
+
+    private AddConnectionReqDto addReq(String guardianPhone, String name) {
+        AddConnectionReqDto dto = new AddConnectionReqDto();
+        ReflectionTestUtils.setField(dto, "guardianPhone", guardianPhone);
+        ReflectionTestUtils.setField(dto, "name", name);
+        return dto;
+    }
+
+    private UpdateConnectionNameReqDto updateNameReq(String name) {
+        UpdateConnectionNameReqDto dto = new UpdateConnectionNameReqDto();
+        ReflectionTestUtils.setField(dto, "name", name);
+        return dto;
+    }
+
+    private Connection connection(User subject, User guardian, String guardianPhone, ConnectionStatus status) {
+        return Connection.builder()
+                .subject(subject)
+                .guardian(guardian)
+                .guardianPhone(guardianPhone)
+                .status(status)
+                .build();
+    }
+
+    // ─── addConnection ─────────────────────────────────────────────────────
+
+    @Test
+    void addConnection_보호자역할_예외발생() {
+        User guardian = user("01011111111", Role.GUARDIAN);
+        given(userService.getByPhone("01011111111")).willReturn(guardian);
+
+        assertThatThrownBy(() -> connectionService.addConnection("01011111111", addReq("01022222222", "엄마")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CONNECTION_SUBJECT_ONLY);
+    }
+
+    @Test
+    void addConnection_중복등록_예외발생() {
+        User subject = user("01011111111", Role.SUBJECT);
+        given(userService.getByPhone("01011111111")).willReturn(subject);
+        given(connectionRepository.existsBySubjectAndGuardianPhone(subject, "01022222222")).willReturn(true);
+
+        assertThatThrownBy(() -> connectionService.addConnection("01011111111", addReq("01022222222", "엄마")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CONNECTION_ALREADY_EXISTS);
+    }
+
+    @Test
+    void addConnection_5명초과_예외발생() {
+        User subject = user("01011111111", Role.SUBJECT);
+        given(userService.getByPhone("01011111111")).willReturn(subject);
+        given(connectionRepository.existsBySubjectAndGuardianPhone(subject, "01022222222")).willReturn(false);
+        given(connectionRepository.countBySubject(subject)).willReturn(5L);
+
+        assertThatThrownBy(() -> connectionService.addConnection("01011111111", addReq("01022222222", "엄마")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.GUARDIAN_LIMIT_EXCEEDED);
+    }
+
+    @Test
+    void addConnection_보호자미가입_PENDING생성() {
+        User subject = user("01011111111", Role.SUBJECT);
+        given(userService.getByPhone("01011111111")).willReturn(subject);
+        given(connectionRepository.existsBySubjectAndGuardianPhone(subject, "01022222222")).willReturn(false);
+        given(connectionRepository.countBySubject(subject)).willReturn(0L);
+        given(userService.findByPhone("01022222222")).willReturn(Optional.empty());
+
+        var resp = connectionService.addConnection("01011111111", addReq("01022222222", "엄마"));
+
+        verify(connectionRepository).save(any(Connection.class));
+        assertThat(resp.getStatus()).isEqualTo(ConnectionStatus.PENDING);
+    }
+
+    @Test
+    void addConnection_보호자가입됨_CONNECTED생성() {
+        User subject = user("01011111111", Role.SUBJECT);
+        User guardian = user("01022222222", Role.GUARDIAN);
+        given(userService.getByPhone("01011111111")).willReturn(subject);
+        given(connectionRepository.existsBySubjectAndGuardianPhone(subject, "01022222222")).willReturn(false);
+        given(connectionRepository.countBySubject(subject)).willReturn(0L);
+        given(userService.findByPhone("01022222222")).willReturn(Optional.of(guardian));
+
+        var resp = connectionService.addConnection("01011111111", addReq("01022222222", "엄마"));
+
+        assertThat(resp.getStatus()).isEqualTo(ConnectionStatus.CONNECTED);
+    }
+
+    // ─── activatePendingConnections ────────────────────────────────────────
+
+    @Test
+    void activatePendingConnections_PENDING연결_CONNECTED전환() {
+        User subject = user("01011111111", Role.SUBJECT);
+        User guardian = user("01022222222", Role.GUARDIAN);
+        Connection pending = connection(subject, null, "01022222222", ConnectionStatus.PENDING);
+        given(connectionRepository.findByGuardianPhoneAndStatus("01022222222", ConnectionStatus.PENDING))
+                .willReturn(List.of(pending));
+
+        connectionService.activatePendingConnections("01022222222", guardian);
+
+        assertThat(pending.getGuardian()).isEqualTo(guardian);
+        assertThat(pending.getStatus()).isEqualTo(ConnectionStatus.CONNECTED);
+    }
+
+    // ─── getConnections ────────────────────────────────────────────────────
+
+    @Test
+    void getConnections_당사자_본인연결목록반환() {
+        User subject = user("01011111111", Role.SUBJECT);
+        User guardian = user("01022222222", Role.GUARDIAN);
+        Connection conn = connection(subject, guardian, "01022222222", ConnectionStatus.CONNECTED);
+        given(userService.getByPhone("01011111111")).willReturn(subject);
+        given(connectionRepository.findBySubject(subject)).willReturn(List.of(conn));
+
+        var resp = connectionService.getConnections("01011111111");
+
+        assertThat(resp.getRole()).isEqualTo(Role.SUBJECT);
+        assertThat(resp.getConnections()).hasSize(1);
+    }
+
+    @Test
+    void getConnections_보호자_담당연결목록반환() {
+        User subject = user("01011111111", Role.SUBJECT);
+        User guardian = user("01022222222", Role.GUARDIAN);
+        Connection conn = connection(subject, guardian, "01022222222", ConnectionStatus.CONNECTED);
+        given(userService.getByPhone("01022222222")).willReturn(guardian);
+        given(connectionRepository.findByGuardian(guardian)).willReturn(List.of(conn));
+        given(checkInService.getLatestCheckInBySubject(subject))
+                .willReturn(new GetLatestCheckInRespDto(null, false));
+
+        var resp = connectionService.getConnections("01022222222");
+
+        assertThat(resp.getRole()).isEqualTo(Role.GUARDIAN);
+        assertThat(resp.getConnections()).hasSize(1);
+    }
+
+    // ─── updateConnectionName ──────────────────────────────────────────────
+
+    @Test
+    void updateConnectionName_당사자_본인연결_이름수정() {
+        User subject = user("01011111111", Role.SUBJECT);
+        Connection conn = connection(subject, null, "01022222222", ConnectionStatus.PENDING);
+        ReflectionTestUtils.setField(conn, "id", 1L);
+        ReflectionTestUtils.setField(subject, "id", 1L);
+        given(userService.getByPhone("01011111111")).willReturn(subject);
+        given(connectionRepository.findById(1L)).willReturn(Optional.of(conn));
+
+        connectionService.updateConnectionName(1L, "01011111111", updateNameReq("새이름"));
+
+        assertThat(conn.getSubjectGivenName()).isEqualTo("새이름");
+    }
+
+    @Test
+    void updateConnectionName_당사자_다른연결_예외발생() {
+        User subject = user("01011111111", Role.SUBJECT);
+        User other = user("01099999999", Role.SUBJECT);
+        ReflectionTestUtils.setField(subject, "id", 1L);
+        ReflectionTestUtils.setField(other, "id", 2L);
+        Connection conn = connection(other, null, "01022222222", ConnectionStatus.PENDING);
+        given(userService.getByPhone("01011111111")).willReturn(subject);
+        given(connectionRepository.findById(1L)).willReturn(Optional.of(conn));
+
+        assertThatThrownBy(() -> connectionService.updateConnectionName(1L, "01011111111", updateNameReq("새이름")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CONNECTION_FORBIDDEN);
+    }
+
+    @Test
+    void updateConnectionName_보호자_본인연결_이름수정() {
+        User subject = user("01011111111", Role.SUBJECT);
+        User guardian = user("01022222222", Role.GUARDIAN);
+        ReflectionTestUtils.setField(guardian, "id", 2L);
+        Connection conn = connection(subject, guardian, "01022222222", ConnectionStatus.CONNECTED);
+        given(userService.getByPhone("01022222222")).willReturn(guardian);
+        given(connectionRepository.findById(1L)).willReturn(Optional.of(conn));
+
+        connectionService.updateConnectionName(1L, "01022222222", updateNameReq("새이름"));
+
+        assertThat(conn.getGuardianGivenName()).isEqualTo("새이름");
+    }
+
+    @Test
+    void updateConnectionName_보호자_다른연결_예외발생() {
+        User guardian = user("01022222222", Role.GUARDIAN);
+        User otherGuardian = user("01033333333", Role.GUARDIAN);
+        ReflectionTestUtils.setField(guardian, "id", 2L);
+        ReflectionTestUtils.setField(otherGuardian, "id", 3L);
+        Connection conn = connection(user("01011111111", Role.SUBJECT), otherGuardian, "01033333333", ConnectionStatus.CONNECTED);
+        given(userService.getByPhone("01022222222")).willReturn(guardian);
+        given(connectionRepository.findById(1L)).willReturn(Optional.of(conn));
+
+        assertThatThrownBy(() -> connectionService.updateConnectionName(1L, "01022222222", updateNameReq("새이름")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CONNECTION_FORBIDDEN);
+    }
+}

--- a/src/test/java/com/guegue/duty_checker/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/guegue/duty_checker/notification/service/NotificationServiceTest.java
@@ -1,0 +1,124 @@
+package com.guegue.duty_checker.notification.service;
+
+import com.guegue.duty_checker.checkin.dto.GetLatestCheckInRespDto;
+import com.guegue.duty_checker.checkin.service.CheckInService;
+import com.guegue.duty_checker.connection.domain.Connection;
+import com.guegue.duty_checker.connection.domain.ConnectionStatus;
+import com.guegue.duty_checker.connection.repository.ConnectionRepository;
+import com.guegue.duty_checker.notification.infrastructure.FcmProvider;
+import com.guegue.duty_checker.notification.repository.NotificationLogRepository;
+import com.guegue.duty_checker.user.domain.Role;
+import com.guegue.duty_checker.user.domain.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @InjectMocks NotificationService notificationService;
+
+    @Mock ConnectionRepository connectionRepository;
+    @Mock CheckInService checkInService;
+    @Mock NotificationLogRepository notificationLogRepository;
+    @Mock FcmProvider fcmProvider;
+
+    private User subject(String phone) {
+        return User.builder().phone(phone).password("pw").role(Role.SUBJECT).build();
+    }
+
+    private User guardianWithToken(String phone, String fcmToken) {
+        User u = User.builder().phone(phone).password("pw").role(Role.GUARDIAN).build();
+        u.updateFcmToken(fcmToken);
+        return u;
+    }
+
+    private User guardianNoToken(String phone) {
+        return User.builder().phone(phone).password("pw").role(Role.GUARDIAN).build();
+    }
+
+    private Connection connected(User subject, User guardian) {
+        return Connection.builder()
+                .subject(subject)
+                .guardian(guardian)
+                .guardianPhone(guardian.getPhone())
+                .status(ConnectionStatus.CONNECTED)
+                .build();
+    }
+
+    // ─── sendMissingCheckInAlerts ──────────────────────────────────────────
+
+    @Test
+    void sendMissingCheckInAlerts_FCM토큰없는보호자_알림스킵() {
+        User subject = subject("01011111111");
+        User guardian = guardianNoToken("01022222222");
+        given(connectionRepository.findByStatus(ConnectionStatus.CONNECTED))
+                .willReturn(List.of(connected(subject, guardian)));
+
+        notificationService.sendMissingCheckInAlerts();
+
+        verify(fcmProvider, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void sendMissingCheckInAlerts_24시간이내체크인_알림스킵() {
+        User subject = subject("01011111111");
+        User guardian = guardianWithToken("01022222222", "token-abc");
+        ZonedDateTime recentCheckIn = ZonedDateTime.now().minusHours(1);
+        given(connectionRepository.findByStatus(ConnectionStatus.CONNECTED))
+                .willReturn(List.of(connected(subject, guardian)));
+        given(checkInService.getLatestCheckInBySubject(subject))
+                .willReturn(new GetLatestCheckInRespDto(recentCheckIn, true));
+
+        notificationService.sendMissingCheckInAlerts();
+
+        verify(fcmProvider, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void sendMissingCheckInAlerts_오늘이미알림발송됨_알림스킵() {
+        User subject = subject("01011111111");
+        User guardian = guardianWithToken("01022222222", "token-abc");
+        ZonedDateTime old = ZonedDateTime.now().minusHours(25);
+        given(connectionRepository.findByStatus(ConnectionStatus.CONNECTED))
+                .willReturn(List.of(connected(subject, guardian)));
+        given(checkInService.getLatestCheckInBySubject(subject))
+                .willReturn(new GetLatestCheckInRespDto(old, false));
+        given(notificationLogRepository.existsBySubjectAndGuardianAndNotifiedDate(any(), any(), any()))
+                .willReturn(true);
+
+        notificationService.sendMissingCheckInAlerts();
+
+        verify(fcmProvider, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void sendMissingCheckInAlerts_정상_알림발송및로그저장() {
+        User subject = subject("01011111111");
+        User guardian = guardianWithToken("01022222222", "token-abc");
+        ZonedDateTime old = ZonedDateTime.now().minusHours(25);
+        given(connectionRepository.findByStatus(ConnectionStatus.CONNECTED))
+                .willReturn(List.of(connected(subject, guardian)));
+        given(checkInService.getLatestCheckInBySubject(subject))
+                .willReturn(new GetLatestCheckInRespDto(old, false));
+        given(notificationLogRepository.existsBySubjectAndGuardianAndNotifiedDate(any(), any(), any()))
+                .willReturn(false);
+
+        notificationService.sendMissingCheckInAlerts();
+
+        verify(fcmProvider).send(anyString(), anyString(), anyString());
+        verify(notificationLogRepository).save(any());
+    }
+}


### PR DESCRIPTION
## Summary

- `AuthServiceTest` (13개) — 쿨다운, 인증코드 만료/불일치/횟수초과, 미인증 가입 거부, 중복 가입, 비밀번호 불일치, 토큰 갱신
- `ConnectionServiceTest` (12개) — 역할 제한, 중복 등록, 5명 초과, PENDING/CONNECTED 생성, 자동 활성화, 이름 수정 권한
- `CheckInServiceTest` (7개) — 역할 제한, 하루 1회 중복 방지, 최신 체크인 오늘 여부
- `NotificationServiceTest` (4개) — FCM 토큰 없는 보호자 스킵, 24h 이내 체크인 스킵, 중복 알림 방지, 정상 발송

**총 36개 테스트 전원 통과**

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)