### PR TITLE
#42 Docker 인프라 세팅 (Dockerfile, docker-compose, Traefik)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# MySQL
+MYSQL_ROOT_PASSWORD=changeme
+MYSQL_DATABASE=duty_checker
+MYSQL_USER=app
+MYSQL_PASSWORD=changeme
+
+# JWT
+JWT_SECRET=your-secret-key-must-be-at-least-256-bits-long-for-hs256

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# ---- Build Stage ----
+FROM gradle:8.13-jdk21 AS builder
+WORKDIR /app
+COPY . .
+RUN ./gradlew clean build -x test
+
+# ---- Runtime Stage ----
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=builder /app/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,80 @@
+version: "3.9"
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: duty-checker-mysql
+    networks:
+      - traefik-net
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      TZ: Asia/Seoul
+    volumes:
+      - mysql-data:/var/lib/mysql
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    restart: always
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    container_name: duty-checker-redis
+    networks:
+      - traefik-net
+    volumes:
+      - redis-data:/data
+    restart: always
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  duty-checker:
+    image: duty-checker-api:latest
+    container_name: duty-checker
+    networks:
+      - traefik-net
+    ports:
+      - "8081:8080"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.duty-checker.rule=Host(`duty-checker.guegue.dev`)"
+      - "traefik.http.routers.duty-checker.entrypoints=websecure"
+      - "traefik.http.routers.duty-checker.tls.certresolver=le"
+      - "traefik.http.services.duty-checker.loadbalancer.server.port=8080"
+    environment:
+      - SPRING_PROFILES_ACTIVE=prod
+      - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true
+      - SPRING_DATASOURCE_USERNAME=${MYSQL_USER}
+      - SPRING_DATASOURCE_PASSWORD=${MYSQL_PASSWORD}
+      - SPRING_DATA_REDIS_HOST=redis
+      - SPRING_DATA_REDIS_PORT=6379
+      - JWT_SECRET=${JWT_SECRET}
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+volumes:
+  mysql-data:
+    driver: local
+  redis-data:
+    driver: local
+
+networks:
+  traefik-net:
+    external: true

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,0 +1,28 @@
+spring:
+  datasource:
+    url: ${SPRING_DATASOURCE_URL}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
+  h2:
+    console:
+      enabled: false
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+  data:
+    redis:
+      host: ${SPRING_DATA_REDIS_HOST}
+      port: ${SPRING_DATA_REDIS_PORT}
+
+jwt:
+  secret: ${JWT_SECRET}
+
+logging:
+  level:
+    com.guegue.duty_checker: INFO
+    org.hibernate.SQL: WARN


### PR DESCRIPTION
## Summary

- `Dockerfile`: multi-stage 빌드 (Gradle 빌드 스테이지 → eclipse-temurin JRE 21 런타임 스테이지)
- `docker-compose.yml`: MySQL 8.0 + Redis 7 + 앱 서비스, 호스트 포트 8081, Traefik 라우팅 `duty-checker.guegue.dev`
- `application-prod.yaml`: prod 프로파일 — MySQL 연결, Redis 연결, 환경변수로 민감정보 주입
- `.env.example`: 서버에서 `.env` 생성 시 참고할 템플릿
- `build.gradle`: `mysql-connector-j` 드라이버 추가
- `.gitignore`: `.env` 파일 제외

## 홈서버 배포 절차

```bash
# 1. 레포 클론 또는 pull
git pull origin main

# 2. .env 파일 생성 (.env.example 참고)
cp .env.example .env
# .env 파일에 실제 값 입력

# 3. 이미지 빌드
docker build -t duty-checker-api:latest .

# 4. 컨테이너 실행
docker-compose up -d
```

## Test plan

- [ ] `./gradlew clean build` 통과 확인
- [ ] 홈서버에서 `docker build` 성공 확인
- [ ] `docker-compose up -d` 후 MySQL, Redis, 앱 헬스체크 통과 확인
- [ ] `duty-checker.guegue.dev` Traefik 라우팅 동작 확인

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)