### PR TITLE
#48 docker-compose MySQL/Redis 별도 서비스 제거 (기존 컨테이너 재사용)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,6 @@
-# MySQL
-MYSQL_ROOT_PASSWORD=changeme
+# MySQL (group-study-mysql 컨테이너 계정 사용)
 MYSQL_DATABASE=duty_checker
-MYSQL_USER=app
+MYSQL_USER=admin
 MYSQL_PASSWORD=changeme
 
 # JWT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,41 +1,5 @@
 version: "3.9"
 services:
-  mysql:
-    image: mysql:8.0
-    container_name: duty-checker-mysql
-    networks:
-      - traefik-net
-    environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
-      MYSQL_USER: ${MYSQL_USER}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-      TZ: Asia/Seoul
-    volumes:
-      - mysql-data:/var/lib/mysql
-    command:
-      - --character-set-server=utf8mb4
-      - --collation-server=utf8mb4_unicode_ci
-    restart: always
-    healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
-      timeout: 20s
-      retries: 10
-
-  redis:
-    image: redis:7-alpine
-    container_name: duty-checker-redis
-    networks:
-      - traefik-net
-    volumes:
-      - redis-data:/data
-    restart: always
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
-      timeout: 3s
-      retries: 5
-
   duty-checker:
     image: duty-checker-api:latest
     container_name: duty-checker
@@ -51,29 +15,18 @@ services:
       - "traefik.http.services.duty-checker.loadbalancer.server.port=8080"
     environment:
       - SPRING_PROFILES_ACTIVE=prod
-      - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true
+      - SPRING_DATASOURCE_URL=jdbc:mysql://group-study-mysql:3306/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true
       - SPRING_DATASOURCE_USERNAME=${MYSQL_USER}
       - SPRING_DATASOURCE_PASSWORD=${MYSQL_PASSWORD}
-      - SPRING_DATA_REDIS_HOST=redis
+      - SPRING_DATA_REDIS_HOST=group-study-redis
       - SPRING_DATA_REDIS_PORT=6379
       - JWT_SECRET=${JWT_SECRET}
-    depends_on:
-      mysql:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
     restart: always
     logging:
       driver: "json-file"
       options:
         max-size: "10m"
         max-file: "5"
-
-volumes:
-  mysql-data:
-    driver: local
-  redis-data:
-    driver: local
 
 networks:
   traefik-net:


### PR DESCRIPTION
## Summary

홈서버에서 기존 운영 중인 `group-study-mysql`, `group-study-redis` 컨테이너를 재사용.
duty-checker 전용 MySQL/Redis를 별도로 띄우지 않아 리소스 절약.

- `docker-compose.yml`: mysql, redis 서비스 제거, 앱 서비스만 남김
- datasource URL: `group-study-mysql:3306`
- redis host: `group-study-redis`
- `.env.example`: `MYSQL_ROOT_PASSWORD` 제거

## 홈서버 배포 전 준비

```sql
-- group-study-mysql 컨테이너에서 실행
CREATE DATABASE duty_checker CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
GRANT ALL PRIVILEGES ON duty_checker.* TO 'admin'@'%';
FLUSH PRIVILEGES;
```

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)