### PR TITLE
#50 MockSmsProvider @Profile 제거로 prod 기동 오류 수정

### DIFF
--- a/src/main/java/com/guegue/duty_checker/auth/infrastructure/MockSmsProvider.java
+++ b/src/main/java/com/guegue/duty_checker/auth/infrastructure/MockSmsProvider.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@Profile("!prod")
 public class MockSmsProvider implements SmsProvider {
 
     @Override


### PR DESCRIPTION
## Summary
- `MockSmsProvider`의 `@Profile("!prod")` 어노테이션 제거
- prod 프로필에서도 MockSmsProvider가 빈으로 등록되어 기동 오류 해결
- 추후 실제 SMS 서비스 연동 시 `@Profile("prod")` 구현체를 추가하면 자동 대체됨

## Test plan
- [ ] `./gradlew clean build` 통과 확인
- [ ] Docker 컨테이너 `SPRING_PROFILES_ACTIVE=prod`로 정상 기동 확인

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)