### PR TITLE
#60 GET /auth/check-phone — 전화번호 가입 여부 확인 API 구현

### DIFF
--- a/src/main/java/com/guegue/duty_checker/auth/controller/AuthController.java
+++ b/src/main/java/com/guegue/duty_checker/auth/controller/AuthController.java
@@ -3,23 +3,40 @@ package com.guegue.duty_checker.auth.controller;
 import com.guegue.duty_checker.auth.dto.*;
 import com.guegue.duty_checker.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Auth", description = "인증/인가 API")
+@Validated
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 public class AuthController {
 
     private final AuthService authService;
+
+    @Operation(summary = "전화번호 가입 여부 확인", description = "전화번호로 이미 가입된 사용자인지 확인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 전화번호 형식")
+    })
+    @GetMapping("/check-phone")
+    public ResponseEntity<CheckPhoneRespDto> checkPhone(
+            @Parameter(description = "확인할 전화번호 (숫자 10~11자리, 예: 01012345678)")
+            @RequestParam @Pattern(regexp = "^01[0-9]{8,9}$", message = "전화번호 형식이 올바르지 않습니다") String phone
+    ) {
+        return ResponseEntity.ok(authService.checkPhone(phone));
+    }
 
     @Operation(summary = "인증 코드 발송", description = "입력한 전화번호로 SMS 인증 코드를 발송합니다.")
     @ApiResponses({

--- a/src/main/java/com/guegue/duty_checker/auth/dto/CheckPhoneRespDto.java
+++ b/src/main/java/com/guegue/duty_checker/auth/dto/CheckPhoneRespDto.java
@@ -1,0 +1,11 @@
+package com.guegue.duty_checker.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CheckPhoneRespDto {
+
+    private boolean exists;
+}

--- a/src/main/java/com/guegue/duty_checker/auth/service/AuthService.java
+++ b/src/main/java/com/guegue/duty_checker/auth/service/AuthService.java
@@ -111,6 +111,10 @@ public class AuthService {
         return new RefreshTokenRespDto(newAccessToken, newRefreshToken);
     }
 
+    public CheckPhoneRespDto checkPhone(String phone) {
+        return new CheckPhoneRespDto(userService.existsByPhone(phone));
+    }
+
     private String generateCode() {
         return String.format("%06d", new Random().nextInt(1_000_000));
     }

--- a/src/test/java/com/guegue/duty_checker/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/guegue/duty_checker/auth/service/AuthServiceTest.java
@@ -71,6 +71,26 @@ class AuthServiceTest {
         return User.builder().phone(phone).password("encoded").role(role).build();
     }
 
+    // ─── checkPhone ────────────────────────────────────────────────────────
+
+    @Test
+    void checkPhone_가입된번호_exists참() {
+        given(userService.existsByPhone("01011111111")).willReturn(true);
+
+        CheckPhoneRespDto resp = authService.checkPhone("01011111111");
+
+        assertThat(resp.isExists()).isTrue();
+    }
+
+    @Test
+    void checkPhone_미가입번호_exists거짓() {
+        given(userService.existsByPhone("01099999999")).willReturn(false);
+
+        CheckPhoneRespDto resp = authService.checkPhone("01099999999");
+
+        assertThat(resp.isExists()).isFalse();
+    }
+
     // ─── sendCode ──────────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

- `GET /api/v1/auth/check-phone?phone={phone}` 엔드포인트 추가
- 전화번호로 기존 가입 여부를 `{ "exists": boolean }` 형식으로 반환
- 인증 불필요 (`/api/v1/auth/**` 기존 permitAll 범위 내)
- `@Validated` + `@Pattern` 으로 전화번호 형식 검증 (10~11자리)

## Test plan

- [ ] `checkPhone_가입된번호_exists참` 테스트 통과 확인
- [ ] `checkPhone_미가입번호_exists거짓` 테스트 통과 확인
- [ ] `./gradlew clean build` 전체 통과 확인
- [ ] Swagger UI에서 `GET /auth/check-phone` 엔드포인트 노출 확인

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)