### PR TITLE
DELETE /api/v1/auth/me — 회원탈퇴 API 구현

### DIFF
--- a/src/main/java/com/guegue/duty_checker/auth/controller/AuthController.java
+++ b/src/main/java/com/guegue/duty_checker/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
@@ -101,5 +102,17 @@ public class AuthController {
     @PostMapping("/refresh")
     public ResponseEntity<RefreshTokenRespDto> refresh(@Valid @RequestBody RefreshTokenReqDto reqDto) {
         return ResponseEntity.ok(authService.refresh(reqDto));
+    }
+
+    @Operation(summary = "회원탈퇴", description = "현재 인증된 사용자의 계정을 탈퇴 처리합니다. 소프트 삭제 방식으로 처리되며, 연관 데이터(연결, 체크인)가 삭제되고 토큰이 무효화됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원탈퇴 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")
+    })
+    @SecurityRequirement(name = "BearerAuth")
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> withdraw(@AuthenticationPrincipal String phone) {
+        authService.withdraw(phone);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/guegue/duty_checker/auth/service/AuthService.java
+++ b/src/main/java/com/guegue/duty_checker/auth/service/AuthService.java
@@ -5,6 +5,7 @@ import com.guegue.duty_checker.auth.infrastructure.RefreshTokenRedisRepository;
 import com.guegue.duty_checker.auth.infrastructure.SmsCodeRedisRepository;
 import com.guegue.duty_checker.auth.infrastructure.SmsProvider;
 import com.guegue.duty_checker.auth.infrastructure.VerifiedPhoneRedisRepository;
+import com.guegue.duty_checker.checkin.service.CheckInService;
 import com.guegue.duty_checker.common.config.JwtProvider;
 import com.guegue.duty_checker.common.exception.BusinessException;
 import com.guegue.duty_checker.common.exception.ErrorCode;
@@ -14,6 +15,7 @@ import com.guegue.duty_checker.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -32,6 +34,7 @@ public class AuthService {
     private final JwtProvider jwtProvider;
     private final UserService userService;
     private final ConnectionService connectionService;
+    private final CheckInService checkInService;
     private final PasswordEncoder passwordEncoder;
 
     public SendCodeRespDto sendCode(SendCodeReqDto reqDto) {
@@ -113,6 +116,15 @@ public class AuthService {
 
     public CheckPhoneRespDto checkPhone(String phone) {
         return new CheckPhoneRespDto(userService.existsByPhone(phone));
+    }
+
+    @Transactional
+    public void withdraw(String phone) {
+        User user = userService.getByPhone(phone);
+        refreshTokenRedisRepository.deleteByPhone(phone);
+        connectionService.deleteAllByUser(user);
+        checkInService.deleteAllByUser(user);
+        userService.deleteUser(phone);
     }
 
     private String generateCode() {

--- a/src/main/java/com/guegue/duty_checker/checkin/repository/CheckInRepository.java
+++ b/src/main/java/com/guegue/duty_checker/checkin/repository/CheckInRepository.java
@@ -12,4 +12,6 @@ public interface CheckInRepository extends JpaRepository<CheckIn, Long> {
     boolean existsBySubjectAndCheckedAtBetween(User subject, ZonedDateTime start, ZonedDateTime end);
 
     Optional<CheckIn> findTopBySubjectOrderByCheckedAtDesc(User subject);
+
+    void deleteBySubject(User subject);
 }

--- a/src/main/java/com/guegue/duty_checker/checkin/service/CheckInService.java
+++ b/src/main/java/com/guegue/duty_checker/checkin/service/CheckInService.java
@@ -72,6 +72,11 @@ public class CheckInService {
         return new GetLatestCheckInRespDto(checkedAt, isTodayChecked);
     }
 
+    @Transactional
+    public void deleteAllByUser(User user) {
+        checkInRepository.deleteBySubject(user);
+    }
+
     @Transactional(readOnly = true)
     public GetLatestCheckInRespDto getLatestCheckInBySubject(User subject) {
         Optional<CheckIn> latest = checkInRepository.findTopBySubjectOrderByCheckedAtDesc(subject);

--- a/src/main/java/com/guegue/duty_checker/common/config/SecurityConfig.java
+++ b/src/main/java/com/guegue/duty_checker/common/config/SecurityConfig.java
@@ -46,8 +46,9 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/health", "/h2-console/**", "/api/v1/auth/**",
-                                "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/health", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/api/v1/auth/me").authenticated()
+                        .requestMatchers("/api/v1/auth/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .headers(h -> h.frameOptions(f -> f.sameOrigin()))

--- a/src/main/java/com/guegue/duty_checker/connection/repository/ConnectionRepository.java
+++ b/src/main/java/com/guegue/duty_checker/connection/repository/ConnectionRepository.java
@@ -19,4 +19,6 @@ public interface ConnectionRepository extends JpaRepository<Connection, Long> {
     long countBySubject(User subject);
 
     List<Connection> findByGuardianPhoneAndStatus(String guardianPhone, com.guegue.duty_checker.connection.domain.ConnectionStatus status);
+
+    void deleteBySubjectOrGuardian(User subject, User guardian);
 }

--- a/src/main/java/com/guegue/duty_checker/connection/service/ConnectionService.java
+++ b/src/main/java/com/guegue/duty_checker/connection/service/ConnectionService.java
@@ -88,6 +88,11 @@ public class ConnectionService {
     }
 
     @Transactional
+    public void deleteAllByUser(User user) {
+        connectionRepository.deleteBySubjectOrGuardian(user, user);
+    }
+
+    @Transactional
     public UpdateConnectionNameRespDto updateConnectionName(Long connectionId, String phone, UpdateConnectionNameReqDto reqDto) {
         User user = userService.getByPhone(phone);
         Connection connection = connectionRepository.findById(connectionId)

--- a/src/main/java/com/guegue/duty_checker/user/domain/User.java
+++ b/src/main/java/com/guegue/duty_checker/user/domain/User.java
@@ -34,6 +34,9 @@ public class User {
     @Column(length = 200)
     private String fcmToken;
 
+    @Column
+    private LocalDateTime deletedAt;
+
     @Builder
     public User(String phone, String password, Role role) {
         this.phone = phone;
@@ -47,6 +50,12 @@ public class User {
     }
 
     public void clearFcmToken() {
+        this.fcmToken = null;
+    }
+
+    public void withdraw() {
+        this.deletedAt = LocalDateTime.now();
+        this.phone = "deleted_" + System.currentTimeMillis() + "_" + this.phone;
         this.fcmToken = null;
     }
 }

--- a/src/main/java/com/guegue/duty_checker/user/repository/UserRepository.java
+++ b/src/main/java/com/guegue/duty_checker/user/repository/UserRepository.java
@@ -10,4 +10,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByPhone(String phone);
 
     boolean existsByPhone(String phone);
+
+    Optional<User> findByPhoneAndDeletedAtIsNull(String phone);
+
+    boolean existsByPhoneAndDeletedAtIsNull(String phone);
 }

--- a/src/main/java/com/guegue/duty_checker/user/service/UserService.java
+++ b/src/main/java/com/guegue/duty_checker/user/service/UserService.java
@@ -16,18 +16,18 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public User getByPhone(String phone) {
-        return userRepository.findByPhone(phone)
+        return userRepository.findByPhoneAndDeletedAtIsNull(phone)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 
     @Transactional(readOnly = true)
     public boolean existsByPhone(String phone) {
-        return userRepository.existsByPhone(phone);
+        return userRepository.existsByPhoneAndDeletedAtIsNull(phone);
     }
 
     @Transactional(readOnly = true)
     public java.util.Optional<User> findByPhone(String phone) {
-        return userRepository.findByPhone(phone);
+        return userRepository.findByPhoneAndDeletedAtIsNull(phone);
     }
 
     @Transactional
@@ -43,5 +43,10 @@ public class UserService {
     @Transactional
     public void clearFcmToken(String phone) {
         getByPhone(phone).clearFcmToken();
+    }
+
+    @Transactional
+    public void deleteUser(String phone) {
+        getByPhone(phone).withdraw();
     }
 }

--- a/src/test/java/com/guegue/duty_checker/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/guegue/duty_checker/auth/service/AuthServiceTest.java
@@ -5,6 +5,7 @@ import com.guegue.duty_checker.auth.infrastructure.*;
 import com.guegue.duty_checker.common.config.JwtProvider;
 import com.guegue.duty_checker.common.exception.BusinessException;
 import com.guegue.duty_checker.common.exception.ErrorCode;
+import com.guegue.duty_checker.checkin.service.CheckInService;
 import com.guegue.duty_checker.connection.service.ConnectionService;
 import com.guegue.duty_checker.user.domain.Role;
 import com.guegue.duty_checker.user.domain.User;
@@ -37,6 +38,7 @@ class AuthServiceTest {
     @Mock JwtProvider jwtProvider;
     @Mock UserService userService;
     @Mock ConnectionService connectionService;
+    @Mock CheckInService checkInService;
     @Mock PasswordEncoder passwordEncoder;
 
     private SendCodeReqDto sendCodeReq(String phone) {
@@ -204,5 +206,31 @@ class AuthServiceTest {
         verify(refreshTokenRedisRepository).deleteByToken("old-refresh");
         assertThat(resp.getAccessToken()).isEqualTo("new-access");
         assertThat(resp.getRefreshToken()).isEqualTo("new-refresh");
+    }
+
+    // ─── withdraw ──────────────────────────────────────────────────────────
+
+    @Test
+    void withdraw_정상_리프레시토큰삭제및연관데이터정리및유저삭제() {
+        User u = user("01011111111", Role.SUBJECT);
+        given(userService.getByPhone("01011111111")).willReturn(u);
+
+        authService.withdraw("01011111111");
+
+        verify(refreshTokenRedisRepository).deleteByPhone("01011111111");
+        verify(connectionService).deleteAllByUser(u);
+        verify(checkInService).deleteAllByUser(u);
+        verify(userService).deleteUser("01011111111");
+    }
+
+    @Test
+    void withdraw_존재하지않는사용자_예외발생() {
+        given(userService.getByPhone("01099999999"))
+                .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        assertThatThrownBy(() -> authService.withdraw("01099999999"))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
     }
 }


### PR DESCRIPTION
Closes #62

## 변경 사항

- User 엔티티에 `deletedAt` 소프트 삭제 필드 및 `withdraw()` 메서드 추가
- 탈퇴 시 `phone`을 `deleted_{timestamp}_{원래phone}` 형식으로 변경하여 동일 번호 재가입 지원
- `UserRepository` / `UserService`에 `DeletedAtIsNull` 기반 조회 메서드로 교체 (탈퇴 사용자 필터링)
- `ConnectionRepository`에 `deleteBySubjectOrGuardian` 추가
- `CheckInRepository`에 `deleteBySubject` 추가
- `ConnectionService` / `CheckInService`에 `deleteAllByUser` 메서드 추가
- `AuthService`에 `@Transactional withdraw()` 메서드 추가 — RefreshToken, Connection, CheckIn 정리 후 소프트 삭제
- `AuthController`에 `DELETE /api/v1/auth/me` 엔드포인트 추가 (Swagger 문서화, `@SecurityRequirement`)
- `AuthServiceTest`에 `withdraw` 단위 테스트 2개 추가 (정상 흐름, 존재하지 않는 사용자 예외)