### PR TITLE
#64 인증 필요 API 경로 분리 — logout, 회원탈퇴 /auth → /users 이동

### DIFF
--- a/src/main/java/com/guegue/duty_checker/auth/controller/AuthController.java
+++ b/src/main/java/com/guegue/duty_checker/auth/controller/AuthController.java
@@ -6,14 +6,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -83,17 +81,6 @@ public class AuthController {
         return ResponseEntity.ok(authService.login(reqDto));
     }
 
-    @Operation(summary = "로그아웃", description = "현재 사용자의 Refresh Token을 무효화하여 로그아웃 처리합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")
-    })
-    @PostMapping("/logout")
-    public ResponseEntity<Void> logout(@AuthenticationPrincipal String phone) {
-        authService.logout(phone);
-        return ResponseEntity.ok().build();
-    }
-
     @Operation(summary = "토큰 갱신", description = "Refresh Token을 사용하여 새로운 Access Token을 발급합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "토큰 갱신 성공"),
@@ -102,17 +89,5 @@ public class AuthController {
     @PostMapping("/refresh")
     public ResponseEntity<RefreshTokenRespDto> refresh(@Valid @RequestBody RefreshTokenReqDto reqDto) {
         return ResponseEntity.ok(authService.refresh(reqDto));
-    }
-
-    @Operation(summary = "회원탈퇴", description = "현재 인증된 사용자의 계정을 탈퇴 처리합니다. 소프트 삭제 방식으로 처리되며, 연관 데이터(연결, 체크인)가 삭제되고 토큰이 무효화됩니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "회원탈퇴 성공"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")
-    })
-    @SecurityRequirement(name = "BearerAuth")
-    @DeleteMapping("/me")
-    public ResponseEntity<Void> withdraw(@AuthenticationPrincipal String phone) {
-        authService.withdraw(phone);
-        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/guegue/duty_checker/common/config/SecurityConfig.java
+++ b/src/main/java/com/guegue/duty_checker/common/config/SecurityConfig.java
@@ -47,7 +47,6 @@ public class SecurityConfig {
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/health", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        .requestMatchers("/api/v1/auth/me").authenticated()
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/guegue/duty_checker/user/controller/UserController.java
+++ b/src/main/java/com/guegue/duty_checker/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.guegue.duty_checker.user.controller;
 
+import com.guegue.duty_checker.auth.service.AuthService;
 import com.guegue.duty_checker.user.dto.UpdateDeviceTokenReqDto;
 import com.guegue.duty_checker.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final AuthService authService;
 
     @Operation(summary = "FCM 디바이스 토큰 업데이트", description = "푸시 알림 수신을 위한 FCM 디바이스 토큰을 등록하거나 갱신합니다.")
     @ApiResponses({
@@ -34,5 +36,28 @@ public class UserController {
             @Valid @RequestBody UpdateDeviceTokenReqDto reqDto) {
         userService.updateFcmToken(phone, reqDto.getFcmToken());
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "로그아웃", description = "현재 사용자의 Refresh Token을 무효화하여 로그아웃 처리합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")
+    })
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal String phone) {
+        authService.logout(phone);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "회원탈퇴", description = "현재 사용자의 계정을 탈퇴 처리합니다. 연결된 Connection과 CheckIn 데이터가 삭제되며 복구할 수 없습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "회원탈퇴 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> withdraw(@AuthenticationPrincipal String phone) {
+        authService.withdraw(phone);
+        return ResponseEntity.noContent().build();
     }
 }


### PR DESCRIPTION
## 변경 내용

인증 필요 엔드포인트가 `/api/v1/auth/**` permitAll 범위에 포함되는 구조적 문제를 해결합니다.

### API 경로 변경

| 구분 | AS-IS | TO-BE |
|------|-------|-------|
| 로그아웃 | `POST /api/v1/auth/logout` | `POST /api/v1/users/logout` |
| 회원탈퇴 | `DELETE /api/v1/auth/me` | `DELETE /api/v1/users/me` |

### SecurityConfig 변경

- `/api/v1/auth/me` 예외 규칙 제거 (workaround 였음)
- `/api/v1/auth/**` 는 public 전용 엔드포인트만 남음
- `/api/v1/users/**` 는 전체 authenticated (예외 없음)

### 파일 변경

- `AuthController.java` — logout, withdraw 엔드포인트 제거
- `UserController.java` — logout (`POST /logout`), withdraw (`DELETE /me`) 추가
- `SecurityConfig.java` — `/api/v1/auth/me` 예외 규칙 제거

Closes #64