### PR TITLE
#74 연결 신청 시 FCM 푸시 알림 발송

### DIFF
--- a/src/main/java/com/guegue/duty_checker/connection/service/ConnectionService.java
+++ b/src/main/java/com/guegue/duty_checker/connection/service/ConnectionService.java
@@ -15,6 +15,7 @@ import com.guegue.duty_checker.connection.dto.UpdateConnectionNameRespDto;
 import com.guegue.duty_checker.connection.dto.UpdateConnectionStatusReqDto;
 import com.guegue.duty_checker.connection.dto.UpdateConnectionStatusRespDto;
 import com.guegue.duty_checker.connection.repository.ConnectionRepository;
+import com.guegue.duty_checker.notification.service.NotificationService;
 import com.guegue.duty_checker.user.domain.Role;
 import com.guegue.duty_checker.user.domain.User;
 import com.guegue.duty_checker.user.service.UserService;
@@ -32,6 +33,7 @@ public class ConnectionService {
     private final ConnectionRepository connectionRepository;
     private final UserService userService;
     private final CheckInService checkInService;
+    private final NotificationService notificationService;
 
     @Transactional
     public AddConnectionRespDto addConnection(String requesterPhone, AddConnectionReqDto reqDto) {
@@ -59,6 +61,7 @@ public class ConnectionService {
                 .status(ConnectionStatus.PENDING)
                 .build();
         connectionRepository.save(connection);
+        notificationService.sendConnectionRequestAlert(target, requester);
 
         return requester.getRole() == Role.SUBJECT
                 ? AddConnectionRespDto.forSubjectRequester(connection)

--- a/src/main/java/com/guegue/duty_checker/notification/service/NotificationService.java
+++ b/src/main/java/com/guegue/duty_checker/notification/service/NotificationService.java
@@ -30,6 +30,17 @@ public class NotificationService {
     private final NotificationLogRepository notificationLogRepository;
     private final FcmProvider fcmProvider;
 
+    public void sendConnectionRequestAlert(User target, User requester) {
+        if (target.getFcmToken() == null) {
+            return;
+        }
+        fcmProvider.send(
+                target.getFcmToken(),
+                "연결 신청이 왔습니다",
+                requester.getPhone() + "님이 연결을 신청했습니다."
+        );
+    }
+
     @Transactional
     public void sendMissingCheckInAlerts() {
         ZonedDateTime now = ZonedDateTime.now(KST);

--- a/src/test/java/com/guegue/duty_checker/connection/service/ConnectionServiceTest.java
+++ b/src/test/java/com/guegue/duty_checker/connection/service/ConnectionServiceTest.java
@@ -10,6 +10,7 @@ import com.guegue.duty_checker.connection.dto.AddConnectionReqDto;
 import com.guegue.duty_checker.connection.dto.UpdateConnectionNameReqDto;
 import com.guegue.duty_checker.connection.dto.UpdateConnectionStatusReqDto;
 import com.guegue.duty_checker.connection.repository.ConnectionRepository;
+import com.guegue.duty_checker.notification.service.NotificationService;
 import com.guegue.duty_checker.user.domain.Role;
 import com.guegue.duty_checker.user.domain.User;
 import com.guegue.duty_checker.user.service.UserService;
@@ -37,6 +38,7 @@ class ConnectionServiceTest {
     @Mock ConnectionRepository connectionRepository;
     @Mock UserService userService;
     @Mock CheckInService checkInService;
+    @Mock NotificationService notificationService;
 
     private User user(String phone, Role role) {
         User u = User.builder().phone(phone).password("pw").role(role).build();

--- a/src/test/java/com/guegue/duty_checker/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/guegue/duty_checker/notification/service/NotificationServiceTest.java
@@ -59,6 +59,28 @@ class NotificationServiceTest {
                 .build();
     }
 
+    // ─── sendConnectionRequestAlert ───────────────────────────────────────
+
+    @Test
+    void sendConnectionRequestAlert_FCM토큰있음_알림발송() {
+        User target = guardianWithToken("01022222222", "token-xyz");
+        User requester = subject("01011111111");
+
+        notificationService.sendConnectionRequestAlert(target, requester);
+
+        verify(fcmProvider).send("token-xyz", "연결 신청이 왔습니다", "01011111111님이 연결을 신청했습니다.");
+    }
+
+    @Test
+    void sendConnectionRequestAlert_FCM토큰없음_알림스킵() {
+        User target = guardianNoToken("01022222222");
+        User requester = subject("01011111111");
+
+        notificationService.sendConnectionRequestAlert(target, requester);
+
+        verify(fcmProvider, never()).send(anyString(), anyString(), anyString());
+    }
+
     // ─── sendMissingCheckInAlerts ──────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

- 연결 신청(POST /connections) 시, 대상이 FCM 토큰을 보유한 기가입자이면 푸시 알림을 발송한다
- FCM 토큰이 없는 경우 알림을 skip한다 (알림 실패가 연결 신청을 막지 않음)

## 변경 내용

| 파일 | 변경 내용 |
|------|-----------|
| `NotificationService` | `sendConnectionRequestAlert(target, requester)` 추가 |
| `ConnectionService` | `NotificationService` 주입, `addConnection` 저장 후 알림 호출 |
| `NotificationServiceTest` | 토큰 유무에 따른 발송/skip 테스트 추가 |
| `ConnectionServiceTest` | `NotificationService` mock 추가 |

### 알림 내용

- **title**: `"연결 신청이 왔습니다"`
- **body**: `"{requesterPhone}님이 연결을 신청했습니다."`

## Test plan

- [x] `./gradlew clean build` 통과
- [x] `sendConnectionRequestAlert_FCM토큰있음_알림발송`
- [x] `sendConnectionRequestAlert_FCM토큰없음_알림스킵`

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)