### PR TITLE
비밀번호 변경 API 구현

### DIFF
--- a/src/main/java/com/guegue/duty_checker/auth/controller/AuthController.java
+++ b/src/main/java/com/guegue/duty_checker/auth/controller/AuthController.java
@@ -6,12 +6,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -89,5 +91,20 @@ public class AuthController {
     @PostMapping("/refresh")
     public ResponseEntity<RefreshTokenRespDto> refresh(@Valid @RequestBody RefreshTokenReqDto reqDto) {
         return ResponseEntity.ok(authService.refresh(reqDto));
+    }
+
+    @Operation(summary = "비밀번호 변경", description = "현재 비밀번호 확인 후 새 비밀번호로 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
+            @ApiResponse(responseCode = "401", description = "현재 비밀번호 불일치 또는 인증 토큰 없음/만료"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    @SecurityRequirement(name = "BearerAuth")
+    @PatchMapping("/password")
+    public ResponseEntity<Void> changePassword(
+            @AuthenticationPrincipal String phone,
+            @Valid @RequestBody ChangePasswordReqDto reqDto) {
+        authService.changePassword(phone, reqDto);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/guegue/duty_checker/auth/dto/ChangePasswordReqDto.java
+++ b/src/main/java/com/guegue/duty_checker/auth/dto/ChangePasswordReqDto.java
@@ -1,0 +1,16 @@
+package com.guegue.duty_checker.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChangePasswordReqDto {
+
+    @NotBlank(message = "현재 비밀번호를 입력해주세요")
+    private String currentPassword;
+
+    @NotBlank(message = "새 비밀번호를 입력해주세요")
+    private String newPassword;
+}

--- a/src/main/java/com/guegue/duty_checker/auth/service/AuthService.java
+++ b/src/main/java/com/guegue/duty_checker/auth/service/AuthService.java
@@ -118,6 +118,19 @@ public class AuthService {
     }
 
     @Transactional
+    public void changePassword(String phone, ChangePasswordReqDto reqDto) {
+        User user = userService.getByPhone(phone);
+        validateCurrentPassword(reqDto.getCurrentPassword(), user.getPassword());
+        user.updatePassword(passwordEncoder.encode(reqDto.getNewPassword()));
+    }
+
+    private void validateCurrentPassword(String rawPassword, String encodedPassword) {
+        if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
+        }
+    }
+
+    @Transactional
     public void withdraw(String phone) {
         User user = userService.getByPhone(phone);
         refreshTokenRedisRepository.deleteByPhone(phone);

--- a/src/main/java/com/guegue/duty_checker/user/domain/User.java
+++ b/src/main/java/com/guegue/duty_checker/user/domain/User.java
@@ -53,6 +53,10 @@ public class User {
         this.fcmToken = null;
     }
 
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+
     public void withdraw() {
         this.deletedAt = LocalDateTime.now();
         this.phone = "deleted_" + System.currentTimeMillis() + "_" + this.phone;

--- a/src/test/java/com/guegue/duty_checker/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/guegue/duty_checker/auth/service/AuthServiceTest.java
@@ -207,6 +207,39 @@ class AuthServiceTest {
         assertThat(resp.getRefreshToken()).isEqualTo("new-refresh");
     }
 
+    // ─── changePassword ────────────────────────────────────────────────────
+
+    private ChangePasswordReqDto changePasswordReq(String currentPassword, String newPassword) {
+        ChangePasswordReqDto dto = new ChangePasswordReqDto();
+        ReflectionTestUtils.setField(dto, "currentPassword", currentPassword);
+        ReflectionTestUtils.setField(dto, "newPassword", newPassword);
+        return dto;
+    }
+
+    @Test
+    void changePassword_현재비밀번호불일치_예외발생() {
+        User u = user("01011111111", Role.SUBJECT);
+        given(userService.getByPhone("01011111111")).willReturn(u);
+        given(passwordEncoder.matches("wrong", "encoded")).willReturn(false);
+
+        assertThatThrownBy(() -> authService.changePassword("01011111111", changePasswordReq("wrong", "new")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_PASSWORD);
+    }
+
+    @Test
+    void changePassword_정상_새비밀번호로업데이트() {
+        User u = user("01011111111", Role.SUBJECT);
+        given(userService.getByPhone("01011111111")).willReturn(u);
+        given(passwordEncoder.matches("current", "encoded")).willReturn(true);
+        given(passwordEncoder.encode("new")).willReturn("new-encoded");
+
+        authService.changePassword("01011111111", changePasswordReq("current", "new"));
+
+        verify(passwordEncoder).encode("new");
+    }
+
     // ─── withdraw ──────────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary
- `PATCH /api/v1/auth/password` 엔드포인트 구현
- 현재 비밀번호 검증 후 bcrypt 암호화된 새 비밀번호로 변경
- Swagger 어노테이션 및 Service 단위 테스트 포함

Closes #81