### PR TITLE
#81 비밀번호 변경 API — 토큰 없이 SMS 인증 기반으로 수정

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -37,7 +37,9 @@ See: .planning/PROJECT.md (updated 2026-03-29)
 | # | Description | Date | Commit | Directory |
 |---|-------------|------|--------|-----------|
 | 260412-s78 | connections api 개선 이슈 생성 | 2026-04-12 | 6575d31 | [260412-s78-connections-api](./quick/260412-s78-connections-api/) |
+| 260416-wwz | ConnectionItemDto에 isRequester 필드 추가 | 2026-04-16 | 70e0d5f | [260416-wwz-connectionitemdto-isrequester](./quick/260416-wwz-connectionitemdto-isrequester/) |
+| 260416-x1w | 비밀번호 변경 API 구현 | 2026-04-16 | 84d916e | [260416-x1w-api](./.planning/quick/260416-x1w-api/) |
 
 ---
 *State initialized: 2026-03-29*
-*Last activity: 2026-04-12 - Completed quick task 260412-s78: connections api 개선 이슈 생성*
+*Last activity: 2026-04-16 - Completed quick task 260416-x1w: 비밀번호 변경 API 구현*

--- a/.planning/quick/260416-x1w-api/260416-x1w-SUMMARY.md
+++ b/.planning/quick/260416-x1w-api/260416-x1w-SUMMARY.md
@@ -1,0 +1,50 @@
+---
+phase: quick-260416-x1w
+plan: 01
+status: complete
+completed: 2026-04-16
+commit: 84d916e
+pr: https://github.com/JinEunPark/duty-checker/pull/82
+issue: https://github.com/JinEunPark/duty-checker/issues/81
+---
+
+# Quick Task 260416-x1w: 비밀번호 변경 API 구현 Summary
+
+**One-liner:** JWT 인증 기반 PATCH /auth/password 엔드포인트 — 현재 비밀번호 검증 후 bcrypt 암호화된 새 비밀번호로 교체
+
+## Tasks Completed
+
+| Task | Description | Status |
+|------|-------------|--------|
+| 1 | GitHub 이슈 #81 생성 및 루트 명세서(#15) 반영, feature/81 브랜치 생성 | Done |
+| 2 | ChangePasswordReqDto, User.updatePassword, AuthService.changePassword, AuthController PATCH /password, 테스트 2개 구현 | Done |
+| 3 | ./gradlew clean build 통과, 커밋, PR 생성 | Done |
+
+## Key Files
+
+**Created:**
+- `src/main/java/com/guegue/duty_checker/auth/dto/ChangePasswordReqDto.java`
+
+**Modified:**
+- `src/main/java/com/guegue/duty_checker/user/domain/User.java` — updatePassword 도메인 메서드 추가
+- `src/main/java/com/guegue/duty_checker/auth/service/AuthService.java` — changePassword, validateCurrentPassword 메서드 추가
+- `src/main/java/com/guegue/duty_checker/auth/controller/AuthController.java` — PATCH /password 엔드포인트 + Swagger 어노테이션 추가
+- `src/test/java/com/guegue/duty_checker/auth/service/AuthServiceTest.java` — changePassword 테스트 2개 추가
+
+## Decisions Made
+
+- `@SecurityRequirement(name = "BearerAuth")`를 클래스 레벨이 아닌 changePassword 메서드에만 적용하여 기존 public 엔드포인트(register, login 등)의 Swagger 표시에 영향을 주지 않음
+
+## Deviations from Plan
+
+None — plan executed exactly as written.
+
+## Self-Check: PASSED
+
+- ChangePasswordReqDto.java: FOUND
+- User.updatePassword method: FOUND
+- AuthService.changePassword method: FOUND
+- AuthController PATCH /password endpoint: FOUND
+- AuthServiceTest changePassword tests: FOUND
+- Commit 84d916e: FOUND
+- PR #82: FOUND

--- a/src/main/java/com/guegue/duty_checker/auth/controller/AuthController.java
+++ b/src/main/java/com/guegue/duty_checker/auth/controller/AuthController.java
@@ -6,14 +6,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -93,18 +91,15 @@ public class AuthController {
         return ResponseEntity.ok(authService.refresh(reqDto));
     }
 
-    @Operation(summary = "비밀번호 변경", description = "현재 비밀번호 확인 후 새 비밀번호로 변경합니다.")
+    @Operation(summary = "비밀번호 변경", description = "SMS 인증 완료 후 새 비밀번호로 변경합니다. 인증 토큰 불필요.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
-            @ApiResponse(responseCode = "401", description = "현재 비밀번호 불일치 또는 인증 토큰 없음/만료"),
+            @ApiResponse(responseCode = "401", description = "전화번호 인증이 되어 있지 않음"),
             @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
     })
-    @SecurityRequirement(name = "BearerAuth")
     @PatchMapping("/password")
-    public ResponseEntity<Void> changePassword(
-            @AuthenticationPrincipal String phone,
-            @Valid @RequestBody ChangePasswordReqDto reqDto) {
-        authService.changePassword(phone, reqDto);
+    public ResponseEntity<Void> changePassword(@Valid @RequestBody ChangePasswordReqDto reqDto) {
+        authService.changePassword(reqDto);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/guegue/duty_checker/auth/dto/ChangePasswordReqDto.java
+++ b/src/main/java/com/guegue/duty_checker/auth/dto/ChangePasswordReqDto.java
@@ -8,8 +8,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ChangePasswordReqDto {
 
-    @NotBlank(message = "현재 비밀번호를 입력해주세요")
-    private String currentPassword;
+    @NotBlank(message = "전화번호를 입력해주세요")
+    private String phone;
 
     @NotBlank(message = "새 비밀번호를 입력해주세요")
     private String newPassword;

--- a/src/main/java/com/guegue/duty_checker/auth/service/AuthService.java
+++ b/src/main/java/com/guegue/duty_checker/auth/service/AuthService.java
@@ -118,15 +118,17 @@ public class AuthService {
     }
 
     @Transactional
-    public void changePassword(String phone, ChangePasswordReqDto reqDto) {
+    public void changePassword(ChangePasswordReqDto reqDto) {
+        String phone = reqDto.getPhone();
+        validatePhoneVerified(phone);
         User user = userService.getByPhone(phone);
-        validateCurrentPassword(reqDto.getCurrentPassword(), user.getPassword());
         user.updatePassword(passwordEncoder.encode(reqDto.getNewPassword()));
+        verifiedPhoneRedisRepository.delete(phone);
     }
 
-    private void validateCurrentPassword(String rawPassword, String encodedPassword) {
-        if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
-            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
+    private void validatePhoneVerified(String phone) {
+        if (!verifiedPhoneRedisRepository.isVerified(phone)) {
+            throw new BusinessException(ErrorCode.PHONE_NOT_VERIFIED);
         }
     }
 

--- a/src/main/java/com/guegue/duty_checker/common/exception/ErrorCode.java
+++ b/src/main/java/com/guegue/duty_checker/common/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     AUTH_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증이 필요합니다"),
     ALREADY_REGISTERED(HttpStatus.CONFLICT, "ALREADY_REGISTERED", "이미 가입된 전화번호입니다"),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "INVALID_PASSWORD", "비밀번호가 올바르지 않습니다"),
+    PHONE_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "PHONE_NOT_VERIFIED", "전화번호 인증이 필요합니다"),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_REFRESH_TOKEN", "refreshToken이 만료되었거나 유효하지 않습니다. 다시 로그인해주세요."),
 
     // User

--- a/src/test/java/com/guegue/duty_checker/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/guegue/duty_checker/auth/service/AuthServiceTest.java
@@ -209,35 +209,34 @@ class AuthServiceTest {
 
     // ─── changePassword ────────────────────────────────────────────────────
 
-    private ChangePasswordReqDto changePasswordReq(String currentPassword, String newPassword) {
+    private ChangePasswordReqDto changePasswordReq(String phone, String newPassword) {
         ChangePasswordReqDto dto = new ChangePasswordReqDto();
-        ReflectionTestUtils.setField(dto, "currentPassword", currentPassword);
+        ReflectionTestUtils.setField(dto, "phone", phone);
         ReflectionTestUtils.setField(dto, "newPassword", newPassword);
         return dto;
     }
 
     @Test
-    void changePassword_현재비밀번호불일치_예외발생() {
-        User u = user("01011111111", Role.SUBJECT);
-        given(userService.getByPhone("01011111111")).willReturn(u);
-        given(passwordEncoder.matches("wrong", "encoded")).willReturn(false);
+    void changePassword_전화번호미인증_예외발생() {
+        given(verifiedPhoneRedisRepository.isVerified("01011111111")).willReturn(false);
 
-        assertThatThrownBy(() -> authService.changePassword("01011111111", changePasswordReq("wrong", "new")))
+        assertThatThrownBy(() -> authService.changePassword(changePasswordReq("01011111111", "new")))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
-                .isEqualTo(ErrorCode.INVALID_PASSWORD);
+                .isEqualTo(ErrorCode.PHONE_NOT_VERIFIED);
     }
 
     @Test
     void changePassword_정상_새비밀번호로업데이트() {
         User u = user("01011111111", Role.SUBJECT);
+        given(verifiedPhoneRedisRepository.isVerified("01011111111")).willReturn(true);
         given(userService.getByPhone("01011111111")).willReturn(u);
-        given(passwordEncoder.matches("current", "encoded")).willReturn(true);
         given(passwordEncoder.encode("new")).willReturn("new-encoded");
 
-        authService.changePassword("01011111111", changePasswordReq("current", "new"));
+        authService.changePassword(changePasswordReq("01011111111", "new"));
 
         verify(passwordEncoder).encode("new");
+        verify(verifiedPhoneRedisRepository).delete("01011111111");
     }
 
     // ─── withdraw ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## 변경 내용

기존 구현이 Bearer Token 기반이었으나, `/api/v1/auth/**`는 `permitAll()`이므로 토큰 없이 SMS 인증 기반으로 수정

### 비밀번호 변경 플로우
```
① POST /auth/send-code     SMS 발송
② POST /auth/verify-code   Redis에 인증 완료 저장 (TTL 10분)
③ PATCH /auth/password     phone + newPassword → 비밀번호 변경 + Redis 삭제
```

### 수정 사항
- `ChangePasswordReqDto`: `currentPassword` → `phone`
- `AuthService`: `verifiedPhoneRedisRepository.isVerified()` 체크 후 변경, 완료 후 Redis 키 삭제
- `AuthController`: `@SecurityRequirement`, `@AuthenticationPrincipal` 제거
- `ErrorCode`: `PHONE_NOT_VERIFIED` 추가
- `AuthServiceTest`: 테스트 로직 수정
- GitHub 이슈 #81 명세서 업데이트

Closes #81