### PR TITLE
#86 Controller 단위 테스트 일괄 작성 (@SpringBootTest + MockMvc)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/guegue/duty_checker/common/config/SecurityConfig.java
+++ b/src/main/java/com/guegue/duty_checker/common/config/SecurityConfig.java
@@ -45,6 +45,13 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.setStatus(jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED);
+                            response.setContentType("application/json;charset=UTF-8");
+                            response.getWriter().write("{\"code\":\"UNAUTHORIZED\",\"message\":\"인증이 필요합니다\"}");
+                        })
+                )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/health", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/api/v1/auth/**").permitAll()

--- a/src/main/java/com/guegue/duty_checker/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/guegue/duty_checker/common/exception/GlobalExceptionHandler.java
@@ -1,12 +1,14 @@
 package com.guegue.duty_checker.common.exception;
 
 import com.guegue.duty_checker.common.response.ErrorResponse;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -28,6 +30,26 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ErrorCode.INVALID_INPUT.getHttpStatus())
                 .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, message));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e) {
+        String message = e.getConstraintViolations().stream()
+                .findFirst()
+                .map(v -> v.getMessage())
+                .orElse(ErrorCode.INVALID_INPUT.getMessage());
+        log.warn("ConstraintViolationException: {}", message);
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT.getHttpStatus())
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, message));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.warn("MethodArgumentTypeMismatchException: {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT.getHttpStatus())
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, ErrorCode.INVALID_INPUT.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/test/java/com/guegue/duty_checker/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/guegue/duty_checker/auth/controller/AuthControllerTest.java
@@ -1,0 +1,169 @@
+package com.guegue.duty_checker.auth.controller;
+
+import com.guegue.duty_checker.auth.dto.CheckPhoneRespDto;
+import com.guegue.duty_checker.auth.dto.LoginRespDto;
+import com.guegue.duty_checker.auth.dto.RefreshTokenRespDto;
+import com.guegue.duty_checker.auth.dto.RegisterRespDto;
+import com.guegue.duty_checker.auth.dto.SendCodeRespDto;
+import com.guegue.duty_checker.auth.infrastructure.RefreshTokenRedisRepository;
+import com.guegue.duty_checker.auth.infrastructure.SmsCodeRedisRepository;
+import com.guegue.duty_checker.auth.infrastructure.VerifiedPhoneRedisRepository;
+import com.guegue.duty_checker.auth.service.AuthService;
+import com.guegue.duty_checker.user.domain.Role;
+import com.guegue.duty_checker.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.ZonedDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class AuthControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AuthService authService;
+
+    @MockitoBean
+    private SmsCodeRedisRepository smsCodeRedisRepository;
+
+    @MockitoBean
+    private RefreshTokenRedisRepository refreshTokenRedisRepository;
+
+    @MockitoBean
+    private VerifiedPhoneRedisRepository verifiedPhoneRedisRepository;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
+
+    private User buildUser(Long id, String phone, Role role) {
+        User user = User.builder()
+                .phone(phone)
+                .password("encoded")
+                .role(role)
+                .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    @Test
+    void checkPhone_유효한전화번호_200반환() throws Exception {
+        given(authService.checkPhone("01012345678")).willReturn(new CheckPhoneRespDto(true));
+
+        mockMvc.perform(get("/api/v1/auth/check-phone")
+                        .param("phone", "01012345678"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.exists").exists());
+    }
+
+    @Test
+    void checkPhone_잘못된형식_400반환() throws Exception {
+        mockMvc.perform(get("/api/v1/auth/check-phone")
+                        .param("phone", "invalid"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void sendCode_정상요청_200반환() throws Exception {
+        given(authService.sendCode(any())).willReturn(new SendCodeRespDto(ZonedDateTime.now()));
+
+        mockMvc.perform(post("/api/v1/auth/send-code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "phone": "01012345678" }
+                                """))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void sendCode_빈전화번호_400반환() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/send-code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "phone": "" }
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void verifyCode_정상요청_204반환() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/verify-code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "phone": "01012345678", "verificationCode": "123456" }
+                                """))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void register_정상요청_201반환() throws Exception {
+        User user = buildUser(1L, "01012345678", Role.SUBJECT);
+        given(authService.register(any())).willReturn(new RegisterRespDto(user));
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "phone": "01012345678", "password": "password123", "role": "SUBJECT" }
+                                """))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void login_정상요청_200반환_직렬화검증() throws Exception {
+        User user = buildUser(1L, "01012345678", Role.SUBJECT);
+        given(authService.login(any())).willReturn(new LoginRespDto("access", "refresh", user));
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "phone": "01012345678", "password": "pw" }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").exists())
+                .andExpect(jsonPath("$.user.role").exists());
+    }
+
+    @Test
+    void refresh_정상요청_200반환() throws Exception {
+        given(authService.refresh(any())).willReturn(new RefreshTokenRespDto("newAccessToken", "newRefreshToken"));
+
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "refreshToken": "token" }
+                                """))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void changePassword_정상요청_200반환() throws Exception {
+        mockMvc.perform(patch("/api/v1/auth/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "phone": "01012345678", "newPassword": "newpass123" }
+                                """))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/guegue/duty_checker/checkin/controller/CheckInControllerTest.java
+++ b/src/test/java/com/guegue/duty_checker/checkin/controller/CheckInControllerTest.java
@@ -1,0 +1,95 @@
+package com.guegue.duty_checker.checkin.controller;
+
+import com.guegue.duty_checker.auth.infrastructure.RefreshTokenRedisRepository;
+import com.guegue.duty_checker.auth.infrastructure.SmsCodeRedisRepository;
+import com.guegue.duty_checker.auth.infrastructure.VerifiedPhoneRedisRepository;
+import com.guegue.duty_checker.checkin.domain.CheckIn;
+import com.guegue.duty_checker.checkin.dto.CreateCheckInRespDto;
+import com.guegue.duty_checker.checkin.dto.GetLatestCheckInRespDto;
+import com.guegue.duty_checker.checkin.service.CheckInService;
+import com.guegue.duty_checker.user.domain.Role;
+import com.guegue.duty_checker.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.ZonedDateTime;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class CheckInControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CheckInService checkInService;
+
+    @MockitoBean
+    private SmsCodeRedisRepository smsCodeRedisRepository;
+
+    @MockitoBean
+    private RefreshTokenRedisRepository refreshTokenRedisRepository;
+
+    @MockitoBean
+    private VerifiedPhoneRedisRepository verifiedPhoneRedisRepository;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
+
+    @Test
+    void createCheckIn_인증없음_401반환() throws Exception {
+        mockMvc.perform(post("/api/v1/check-ins"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getLatestCheckIn_인증없음_401반환() throws Exception {
+        mockMvc.perform(get("/api/v1/check-ins/latest"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "01012345678")
+    void createCheckIn_인증됨_201반환_직렬화검증() throws Exception {
+        // Hibernate 바이트코드 강화로 인해 mock() 대신 실제 엔티티 빌더 + ReflectionTestUtils 사용
+        User subject = User.builder().phone("01012345678").password("pw").role(Role.SUBJECT).build();
+        CheckIn checkIn = CheckIn.builder().subject(subject).checkedAt(ZonedDateTime.now()).build();
+        ReflectionTestUtils.setField(checkIn, "id", 1L);
+        given(checkInService.createCheckIn(any())).willReturn(new CreateCheckInRespDto(checkIn));
+
+        mockMvc.perform(post("/api/v1/check-ins"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.checkedAt").exists());
+        // 500이면 ZonedDateTime Jackson 직렬화 설정 오류
+    }
+
+    @Test
+    @WithMockUser(username = "01012345678")
+    void getLatestCheckIn_인증됨_200반환() throws Exception {
+        given(checkInService.getLatestCheckIn(any())).willReturn(new GetLatestCheckInRespDto(ZonedDateTime.now(), true));
+
+        mockMvc.perform(get("/api/v1/check-ins/latest"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/guegue/duty_checker/common/controller/HealthControllerTest.java
+++ b/src/test/java/com/guegue/duty_checker/common/controller/HealthControllerTest.java
@@ -1,0 +1,50 @@
+package com.guegue.duty_checker.common.controller;
+
+import com.guegue.duty_checker.auth.infrastructure.RefreshTokenRedisRepository;
+import com.guegue.duty_checker.auth.infrastructure.SmsCodeRedisRepository;
+import com.guegue.duty_checker.auth.infrastructure.VerifiedPhoneRedisRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class HealthControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private SmsCodeRedisRepository smsCodeRedisRepository;
+
+    @MockitoBean
+    private RefreshTokenRedisRepository refreshTokenRedisRepository;
+
+    @MockitoBean
+    private VerifiedPhoneRedisRepository verifiedPhoneRedisRepository;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
+
+    @Test
+    void health_인증없이_200반환() throws Exception {
+        mockMvc.perform(get("/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"));
+    }
+}

--- a/src/test/java/com/guegue/duty_checker/connection/controller/ConnectionControllerTest.java
+++ b/src/test/java/com/guegue/duty_checker/connection/controller/ConnectionControllerTest.java
@@ -1,0 +1,251 @@
+package com.guegue.duty_checker.connection.controller;
+
+import com.guegue.duty_checker.auth.infrastructure.RefreshTokenRedisRepository;
+import com.guegue.duty_checker.auth.infrastructure.SmsCodeRedisRepository;
+import com.guegue.duty_checker.auth.infrastructure.VerifiedPhoneRedisRepository;
+import com.guegue.duty_checker.connection.domain.Connection;
+import com.guegue.duty_checker.connection.domain.ConnectionStatus;
+import com.guegue.duty_checker.connection.dto.ConnectionItemDto;
+import com.guegue.duty_checker.connection.dto.GetConnectionsRespDto;
+import com.guegue.duty_checker.connection.dto.UpdateConnectionNameRespDto;
+import com.guegue.duty_checker.connection.dto.UpdateConnectionStatusRespDto;
+import com.guegue.duty_checker.connection.service.ConnectionService;
+import com.guegue.duty_checker.user.domain.Role;
+import com.guegue.duty_checker.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class ConnectionControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ConnectionService connectionService;
+
+    @MockitoBean
+    private SmsCodeRedisRepository smsCodeRedisRepository;
+
+    @MockitoBean
+    private RefreshTokenRedisRepository refreshTokenRedisRepository;
+
+    @MockitoBean
+    private VerifiedPhoneRedisRepository verifiedPhoneRedisRepository;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
+
+    // ==================== 인증 검증 ====================
+
+    @Test
+    void getConnections_인증없음_401반환() throws Exception {
+        mockMvc.perform(get("/api/v1/connections"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void addConnection_인증없음_401반환() throws Exception {
+        mockMvc.perform(post("/api/v1/connections")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "targetPhone": "01012345678" }
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void updateConnectionStatus_인증없음_401반환() throws Exception {
+        mockMvc.perform(patch("/api/v1/connections/1/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "status": "CONNECTED" }
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void updateConnectionName_인증없음_401반환() throws Exception {
+        mockMvc.perform(patch("/api/v1/connections/1/name")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "name": "홍길동" }
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void deleteConnection_인증없음_401반환() throws Exception {
+        mockMvc.perform(delete("/api/v1/connections/1"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ==================== 정상 동작 및 직렬화 검증 ====================
+
+    @Test
+    @WithMockUser(username = "01012345678")
+    void getConnections_인증됨_200반환_직렬화검증() throws Exception {
+        // Hibernate 바이트코드 강화로 인해 mock() 대신 실제 엔티티 빌더 + ReflectionTestUtils 사용
+        User subject = User.builder().phone("01099998888").password("pw").role(Role.SUBJECT).build();
+        User requester = User.builder().phone("01012345678").password("pw").role(Role.GUARDIAN).build();
+        Connection connection = Connection.builder()
+                .subject(subject)
+                .guardianPhone("01012345678")
+                .requester(requester)
+                .guardianGivenName("홍길동")
+                .status(ConnectionStatus.CONNECTED)
+                .build();
+        ReflectionTestUtils.setField(connection, "id", 1L);
+
+        ZonedDateTime now = ZonedDateTime.now();
+        ConnectionItemDto item = ConnectionItemDto.forGuardian(connection, now, false);
+        GetConnectionsRespDto resp = new GetConnectionsRespDto(Role.GUARDIAN, List.of(item));
+        given(connectionService.getConnections(any())).willReturn(resp);
+
+        mockMvc.perform(get("/api/v1/connections"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.connections").isArray())
+                .andExpect(jsonPath("$.connections[0].latestCheckedAt").exists())
+                .andExpect(jsonPath("$.connections[0].requesterRole").exists());
+        // 500이면 ZonedDateTime 또는 Role enum 직렬화 설정 오류
+    }
+
+    @Test
+    @WithMockUser(username = "01012345678")
+    void addConnection_정상요청_201반환() throws Exception {
+        given(connectionService.addConnection(any(), any())).willReturn(null);
+
+        mockMvc.perform(post("/api/v1/connections")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "targetPhone": "01012345678" }
+                                """))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @WithMockUser(username = "01012345678")
+    void updateConnectionStatus_정상요청_200반환() throws Exception {
+        given(connectionService.updateConnectionStatus(eq(1L), any(), any()))
+                .willReturn(new UpdateConnectionStatusRespDto(1L, ConnectionStatus.CONNECTED));
+
+        mockMvc.perform(patch("/api/v1/connections/1/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "status": "CONNECTED" }
+                                """))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "01012345678")
+    void updateConnectionName_정상요청_200반환() throws Exception {
+        User subject = User.builder().phone("01099998888").password("pw").role(Role.SUBJECT).build();
+        User requester = User.builder().phone("01012345678").password("pw").role(Role.GUARDIAN).build();
+        Connection connection = Connection.builder()
+                .subject(subject)
+                .guardianPhone("01012345678")
+                .requester(requester)
+                .guardianGivenName("홍길동")
+                .status(ConnectionStatus.CONNECTED)
+                .build();
+        ReflectionTestUtils.setField(connection, "id", 1L);
+
+        given(connectionService.updateConnectionName(eq(1L), any(), any()))
+                .willReturn(UpdateConnectionNameRespDto.forGuardian(connection));
+
+        mockMvc.perform(patch("/api/v1/connections/1/name")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "name": "홍길동" }
+                                """))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "01012345678")
+    void deleteConnection_정상요청_204반환() throws Exception {
+        mockMvc.perform(delete("/api/v1/connections/1"))
+                .andExpect(status().isNoContent());
+    }
+
+    // ==================== 요청 검증 ====================
+
+    @Test
+    @WithMockUser(username = "01012345678")
+    void addConnection_빈전화번호_400반환() throws Exception {
+        mockMvc.perform(post("/api/v1/connections")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "targetPhone": "" }
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "01012345678")
+    void updateConnectionStatus_status미전달_400반환() throws Exception {
+        mockMvc.perform(patch("/api/v1/connections/1/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "01012345678")
+    void updateConnectionStatus_문자열id_400반환() throws Exception {
+        mockMvc.perform(patch("/api/v1/connections/abc/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "status": "CONNECTED" }
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "01012345678")
+    void updateConnectionName_문자열id_400반환() throws Exception {
+        mockMvc.perform(patch("/api/v1/connections/abc/name")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "name": "홍길동" }
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "01012345678")
+    void deleteConnection_문자열id_400반환() throws Exception {
+        mockMvc.perform(delete("/api/v1/connections/abc"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/guegue/duty_checker/user/controller/UserControllerTest.java
+++ b/src/test/java/com/guegue/duty_checker/user/controller/UserControllerTest.java
@@ -1,0 +1,111 @@
+package com.guegue.duty_checker.user.controller;
+
+import com.guegue.duty_checker.auth.infrastructure.RefreshTokenRedisRepository;
+import com.guegue.duty_checker.auth.infrastructure.SmsCodeRedisRepository;
+import com.guegue.duty_checker.auth.infrastructure.VerifiedPhoneRedisRepository;
+import com.guegue.duty_checker.auth.service.AuthService;
+import com.guegue.duty_checker.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class UserControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private AuthService authService;
+
+    @MockitoBean
+    private SmsCodeRedisRepository smsCodeRedisRepository;
+
+    @MockitoBean
+    private RefreshTokenRedisRepository refreshTokenRedisRepository;
+
+    @MockitoBean
+    private VerifiedPhoneRedisRepository verifiedPhoneRedisRepository;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
+
+    @Test
+    void updateDeviceToken_인증없음_401반환() throws Exception {
+        mockMvc.perform(patch("/api/v1/users/device-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "fcmToken": "token123" }
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void logout_인증없음_401반환() throws Exception {
+        mockMvc.perform(post("/api/v1/users/logout"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void withdraw_인증없음_401반환() throws Exception {
+        mockMvc.perform(delete("/api/v1/users/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "01012345678")
+    void updateDeviceToken_정상요청_200반환() throws Exception {
+        mockMvc.perform(patch("/api/v1/users/device-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "fcmToken": "token123" }
+                                """))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "01012345678")
+    void updateDeviceToken_빈토큰_400반환() throws Exception {
+        mockMvc.perform(patch("/api/v1/users/device-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "fcmToken": "" }
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "01012345678")
+    void logout_정상요청_200반환() throws Exception {
+        mockMvc.perform(post("/api/v1/users/logout"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "01012345678")
+    void withdraw_정상요청_204반환() throws Exception {
+        mockMvc.perform(delete("/api/v1/users/me"))
+                .andExpect(status().isNoContent());
+    }
+}


### PR DESCRIPTION
## 변경 내용

- **AuthControllerTest** (9개): 라우팅·직렬화·@Valid·@Pattern 검증 TC
- **CheckInControllerTest** (4개): 인증 검증, ZonedDateTime 직렬화 TC
- **HealthControllerTest** (1개): 라우팅 TC
- **ConnectionControllerTest** (15개): 인증 검증, ZonedDateTime/enum 직렬화, PathVariable 타입 오류 TC (docs/CONTROLLER_TEST_STRATEGY.md 섹션 6 체크리스트 전체)
- **UserControllerTest** (7개): 인증 검증, @Valid 검증 TC

총 36개 TC — 모두 통과

## 테스트 전략

Spring Boot 4에서 @WebMvcTest 슬라이스가 제거되어 @SpringBootTest(webEnvironment=MOCK) + webAppContextSetup + springSecurity() 조합으로 전환함.
docs/CONTROLLER_TEST_STRATEGY.md 기준. @MockitoBean(Spring Boot 4 @MockBean 대체) 사용.

## 함께 수정된 프로덕션 코드 (Rule 2 — 누락된 필수 기능 자동 추가)

- **GlobalExceptionHandler**: `ConstraintViolationException` 핸들러 추가 → @Validated + @RequestParam @Pattern 위반 시 400 반환
- **GlobalExceptionHandler**: `MethodArgumentTypeMismatchException` 핸들러 추가 → PathVariable 타입 불일치 시 400 반환
- **SecurityConfig**: `AuthenticationEntryPoint` 추가 → 미인증 요청에 403 대신 401 반환
- **build.gradle**: `spring-security-test` 의존성 추가 (Spring Boot 4에서 미포함)

Closes #86