### PR TITLE
#88 fcmToken 다중 디바이스 지원을 위한 UserFcmToken 테이블 정규화

### DIFF
--- a/src/main/java/com/guegue/duty_checker/auth/service/AuthService.java
+++ b/src/main/java/com/guegue/duty_checker/auth/service/AuthService.java
@@ -11,6 +11,7 @@ import com.guegue.duty_checker.common.exception.BusinessException;
 import com.guegue.duty_checker.common.exception.ErrorCode;
 import com.guegue.duty_checker.connection.service.ConnectionService;
 import com.guegue.duty_checker.user.domain.User;
+import com.guegue.duty_checker.user.service.UserFcmTokenService;
 import com.guegue.duty_checker.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -33,6 +34,7 @@ public class AuthService {
     private final SmsProvider smsProvider;
     private final JwtProvider jwtProvider;
     private final UserService userService;
+    private final UserFcmTokenService userFcmTokenService;
     private final ConnectionService connectionService;
     private final CheckInService checkInService;
     private final PasswordEncoder passwordEncoder;
@@ -95,7 +97,7 @@ public class AuthService {
 
     public void logout(String phone) {
         refreshTokenRedisRepository.deleteByPhone(phone);
-        userService.clearFcmToken(phone);
+        userService.findByPhone(phone).ifPresent(userFcmTokenService::deleteAllByUser);
     }
 
     public RefreshTokenRespDto refresh(RefreshTokenReqDto reqDto) {

--- a/src/main/java/com/guegue/duty_checker/notification/service/NotificationService.java
+++ b/src/main/java/com/guegue/duty_checker/notification/service/NotificationService.java
@@ -8,6 +8,7 @@ import com.guegue.duty_checker.notification.domain.NotificationLog;
 import com.guegue.duty_checker.notification.infrastructure.FcmProvider;
 import com.guegue.duty_checker.notification.repository.NotificationLogRepository;
 import com.guegue.duty_checker.user.domain.User;
+import com.guegue.duty_checker.user.service.UserFcmTokenService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,16 +30,20 @@ public class NotificationService {
     private final CheckInService checkInService;
     private final NotificationLogRepository notificationLogRepository;
     private final FcmProvider fcmProvider;
+    private final UserFcmTokenService userFcmTokenService;
 
     public void sendConnectionRequestAlert(User target, User requester) {
-        if (target.getFcmToken() == null) {
+        List<String> tokens = userFcmTokenService.getTokensByUser(target);
+        if (tokens.isEmpty()) {
             return;
         }
-        fcmProvider.send(
-                target.getFcmToken(),
-                "연결 신청이 왔습니다",
-                requester.getPhone() + "님이 연결을 신청했습니다."
-        );
+        for (String token : tokens) {
+            fcmProvider.send(
+                    token,
+                    "연결 신청이 왔습니다",
+                    requester.getPhone() + "님이 연결을 신청했습니다."
+            );
+        }
     }
 
     @Transactional
@@ -53,7 +58,8 @@ public class NotificationService {
             User subject = connection.getSubject();
             User guardian = connection.getGuardian();
 
-            if (guardian.getFcmToken() == null) {
+            List<String> guardianTokens = userFcmTokenService.getTokensByUser(guardian);
+            if (guardianTokens.isEmpty()) {
                 continue;
             }
 
@@ -74,11 +80,13 @@ public class NotificationService {
                     ? connection.getGuardianGivenName()
                     : subject.getPhone();
 
-            fcmProvider.send(
-                    guardian.getFcmToken(),
-                    "안부 확인 알림",
-                    displayName + "님이 24시간 동안 안부 확인을 하지 않았습니다."
-            );
+            for (String token : guardianTokens) {
+                fcmProvider.send(
+                        token,
+                        "안부 확인 알림",
+                        displayName + "님이 24시간 동안 안부 확인을 하지 않았습니다."
+                );
+            }
 
             notificationLogRepository.save(NotificationLog.builder()
                     .subject(subject)

--- a/src/main/java/com/guegue/duty_checker/user/controller/UserController.java
+++ b/src/main/java/com/guegue/duty_checker/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.guegue.duty_checker.user.controller;
 
 import com.guegue.duty_checker.auth.service.AuthService;
 import com.guegue.duty_checker.user.dto.UpdateDeviceTokenReqDto;
+import com.guegue.duty_checker.user.service.UserFcmTokenService;
 import com.guegue.duty_checker.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -22,11 +23,12 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final UserFcmTokenService userFcmTokenService;
     private final AuthService authService;
 
-    @Operation(summary = "FCM 디바이스 토큰 업데이트", description = "푸시 알림 수신을 위한 FCM 디바이스 토큰을 등록하거나 갱신합니다.")
+    @Operation(summary = "FCM 디바이스 토큰 등록", description = "푸시 알림 수신을 위한 FCM 디바이스 토큰을 등록합니다. 이미 등록된 토큰은 중복 저장되지 않습니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "토큰 업데이트 성공"),
+            @ApiResponse(responseCode = "200", description = "토큰 등록 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")
     })
@@ -34,7 +36,7 @@ public class UserController {
     public ResponseEntity<Void> updateDeviceToken(
             @AuthenticationPrincipal String phone,
             @Valid @RequestBody UpdateDeviceTokenReqDto reqDto) {
-        userService.updateFcmToken(phone, reqDto.getFcmToken());
+        userFcmTokenService.saveToken(userService.getByPhone(phone), reqDto.getFcmToken());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/guegue/duty_checker/user/domain/User.java
+++ b/src/main/java/com/guegue/duty_checker/user/domain/User.java
@@ -31,9 +31,6 @@ public class User {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    @Column(length = 200)
-    private String fcmToken;
-
     @Column
     private LocalDateTime deletedAt;
 
@@ -45,14 +42,6 @@ public class User {
         this.createdAt = LocalDateTime.now();
     }
 
-    public void updateFcmToken(String fcmToken) {
-        this.fcmToken = fcmToken;
-    }
-
-    public void clearFcmToken() {
-        this.fcmToken = null;
-    }
-
     public void updatePassword(String encodedPassword) {
         this.password = encodedPassword;
     }
@@ -60,6 +49,5 @@ public class User {
     public void withdraw() {
         this.deletedAt = LocalDateTime.now();
         this.phone = "deleted_" + System.currentTimeMillis() + "_" + this.phone;
-        this.fcmToken = null;
     }
 }

--- a/src/main/java/com/guegue/duty_checker/user/domain/UserFcmToken.java
+++ b/src/main/java/com/guegue/duty_checker/user/domain/UserFcmToken.java
@@ -1,0 +1,37 @@
+package com.guegue.duty_checker.user.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_fcm_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserFcmToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, unique = true, length = 200)
+    private String token;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public UserFcmToken(User user, String token) {
+        this.user = user;
+        this.token = token;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/guegue/duty_checker/user/repository/UserFcmTokenRepository.java
+++ b/src/main/java/com/guegue/duty_checker/user/repository/UserFcmTokenRepository.java
@@ -1,0 +1,16 @@
+package com.guegue.duty_checker.user.repository;
+
+import com.guegue.duty_checker.user.domain.User;
+import com.guegue.duty_checker.user.domain.UserFcmToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserFcmTokenRepository extends JpaRepository<UserFcmToken, Long> {
+
+    List<UserFcmToken> findAllByUser(User user);
+
+    boolean existsByUserAndToken(User user, String token);
+
+    void deleteAllByUser(User user);
+}

--- a/src/main/java/com/guegue/duty_checker/user/service/UserFcmTokenService.java
+++ b/src/main/java/com/guegue/duty_checker/user/service/UserFcmTokenService.java
@@ -1,0 +1,40 @@
+package com.guegue.duty_checker.user.service;
+
+import com.guegue.duty_checker.user.domain.User;
+import com.guegue.duty_checker.user.domain.UserFcmToken;
+import com.guegue.duty_checker.user.repository.UserFcmTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserFcmTokenService {
+
+    private final UserFcmTokenRepository userFcmTokenRepository;
+
+    @Transactional
+    public void saveToken(User user, String token) {
+        if (!userFcmTokenRepository.existsByUserAndToken(user, token)) {
+            userFcmTokenRepository.save(UserFcmToken.builder()
+                    .user(user)
+                    .token(token)
+                    .build());
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<String> getTokensByUser(User user) {
+        return userFcmTokenRepository.findAllByUser(user)
+                .stream()
+                .map(UserFcmToken::getToken)
+                .toList();
+    }
+
+    @Transactional
+    public void deleteAllByUser(User user) {
+        userFcmTokenRepository.deleteAllByUser(user);
+    }
+}

--- a/src/main/java/com/guegue/duty_checker/user/service/UserService.java
+++ b/src/main/java/com/guegue/duty_checker/user/service/UserService.java
@@ -36,16 +36,6 @@ public class UserService {
     }
 
     @Transactional
-    public void updateFcmToken(String phone, String fcmToken) {
-        getByPhone(phone).updateFcmToken(fcmToken);
-    }
-
-    @Transactional
-    public void clearFcmToken(String phone) {
-        getByPhone(phone).clearFcmToken();
-    }
-
-    @Transactional
     public void deleteUser(String phone) {
         getByPhone(phone).withdraw();
     }

--- a/src/test/java/com/guegue/duty_checker/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/guegue/duty_checker/notification/service/NotificationServiceTest.java
@@ -9,12 +9,12 @@ import com.guegue.duty_checker.notification.infrastructure.FcmProvider;
 import com.guegue.duty_checker.notification.repository.NotificationLogRepository;
 import com.guegue.duty_checker.user.domain.Role;
 import com.guegue.duty_checker.user.domain.User;
+import com.guegue.duty_checker.user.service.UserFcmTokenService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -34,18 +34,13 @@ class NotificationServiceTest {
     @Mock CheckInService checkInService;
     @Mock NotificationLogRepository notificationLogRepository;
     @Mock FcmProvider fcmProvider;
+    @Mock UserFcmTokenService userFcmTokenService;
 
     private User subject(String phone) {
         return User.builder().phone(phone).password("pw").role(Role.SUBJECT).build();
     }
 
-    private User guardianWithToken(String phone, String fcmToken) {
-        User u = User.builder().phone(phone).password("pw").role(Role.GUARDIAN).build();
-        u.updateFcmToken(fcmToken);
-        return u;
-    }
-
-    private User guardianNoToken(String phone) {
+    private User guardian(String phone) {
         return User.builder().phone(phone).password("pw").role(Role.GUARDIAN).build();
     }
 
@@ -63,8 +58,9 @@ class NotificationServiceTest {
 
     @Test
     void sendConnectionRequestAlert_FCM토큰있음_알림발송() {
-        User target = guardianWithToken("01022222222", "token-xyz");
+        User target = guardian("01022222222");
         User requester = subject("01011111111");
+        given(userFcmTokenService.getTokensByUser(target)).willReturn(List.of("token-xyz"));
 
         notificationService.sendConnectionRequestAlert(target, requester);
 
@@ -73,8 +69,9 @@ class NotificationServiceTest {
 
     @Test
     void sendConnectionRequestAlert_FCM토큰없음_알림스킵() {
-        User target = guardianNoToken("01022222222");
+        User target = guardian("01022222222");
         User requester = subject("01011111111");
+        given(userFcmTokenService.getTokensByUser(target)).willReturn(List.of());
 
         notificationService.sendConnectionRequestAlert(target, requester);
 
@@ -86,9 +83,10 @@ class NotificationServiceTest {
     @Test
     void sendMissingCheckInAlerts_FCM토큰없는보호자_알림스킵() {
         User subject = subject("01011111111");
-        User guardian = guardianNoToken("01022222222");
+        User guardian = guardian("01022222222");
         given(connectionRepository.findByStatus(ConnectionStatus.CONNECTED))
                 .willReturn(List.of(connected(subject, guardian)));
+        given(userFcmTokenService.getTokensByUser(guardian)).willReturn(List.of());
 
         notificationService.sendMissingCheckInAlerts();
 
@@ -98,10 +96,11 @@ class NotificationServiceTest {
     @Test
     void sendMissingCheckInAlerts_24시간이내체크인_알림스킵() {
         User subject = subject("01011111111");
-        User guardian = guardianWithToken("01022222222", "token-abc");
+        User guardian = guardian("01022222222");
         ZonedDateTime recentCheckIn = ZonedDateTime.now().minusHours(1);
         given(connectionRepository.findByStatus(ConnectionStatus.CONNECTED))
                 .willReturn(List.of(connected(subject, guardian)));
+        given(userFcmTokenService.getTokensByUser(guardian)).willReturn(List.of("token-abc"));
         given(checkInService.getLatestCheckInBySubject(subject))
                 .willReturn(new GetLatestCheckInRespDto(recentCheckIn, true));
 
@@ -113,10 +112,11 @@ class NotificationServiceTest {
     @Test
     void sendMissingCheckInAlerts_오늘이미알림발송됨_알림스킵() {
         User subject = subject("01011111111");
-        User guardian = guardianWithToken("01022222222", "token-abc");
+        User guardian = guardian("01022222222");
         ZonedDateTime old = ZonedDateTime.now().minusHours(25);
         given(connectionRepository.findByStatus(ConnectionStatus.CONNECTED))
                 .willReturn(List.of(connected(subject, guardian)));
+        given(userFcmTokenService.getTokensByUser(guardian)).willReturn(List.of("token-abc"));
         given(checkInService.getLatestCheckInBySubject(subject))
                 .willReturn(new GetLatestCheckInRespDto(old, false));
         given(notificationLogRepository.existsBySubjectAndGuardianAndNotifiedDate(any(), any(), any()))
@@ -130,10 +130,11 @@ class NotificationServiceTest {
     @Test
     void sendMissingCheckInAlerts_정상_알림발송및로그저장() {
         User subject = subject("01011111111");
-        User guardian = guardianWithToken("01022222222", "token-abc");
+        User guardian = guardian("01022222222");
         ZonedDateTime old = ZonedDateTime.now().minusHours(25);
         given(connectionRepository.findByStatus(ConnectionStatus.CONNECTED))
                 .willReturn(List.of(connected(subject, guardian)));
+        given(userFcmTokenService.getTokensByUser(guardian)).willReturn(List.of("token-abc"));
         given(checkInService.getLatestCheckInBySubject(subject))
                 .willReturn(new GetLatestCheckInRespDto(old, false));
         given(notificationLogRepository.existsBySubjectAndGuardianAndNotifiedDate(any(), any(), any()))

--- a/src/test/java/com/guegue/duty_checker/user/controller/UserControllerTest.java
+++ b/src/test/java/com/guegue/duty_checker/user/controller/UserControllerTest.java
@@ -4,6 +4,7 @@ import com.guegue.duty_checker.auth.infrastructure.RefreshTokenRedisRepository;
 import com.guegue.duty_checker.auth.infrastructure.SmsCodeRedisRepository;
 import com.guegue.duty_checker.auth.infrastructure.VerifiedPhoneRedisRepository;
 import com.guegue.duty_checker.auth.service.AuthService;
+import com.guegue.duty_checker.user.service.UserFcmTokenService;
 import com.guegue.duty_checker.user.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,9 @@ class UserControllerTest {
 
     @MockitoBean
     private UserService userService;
+
+    @MockitoBean
+    private UserFcmTokenService userFcmTokenService;
 
     @MockitoBean
     private AuthService authService;

--- a/src/test/java/com/guegue/duty_checker/user/service/UserFcmTokenServiceTest.java
+++ b/src/test/java/com/guegue/duty_checker/user/service/UserFcmTokenServiceTest.java
@@ -1,0 +1,92 @@
+package com.guegue.duty_checker.user.service;
+
+import com.guegue.duty_checker.user.domain.Role;
+import com.guegue.duty_checker.user.domain.User;
+import com.guegue.duty_checker.user.domain.UserFcmToken;
+import com.guegue.duty_checker.user.repository.UserFcmTokenRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserFcmTokenServiceTest {
+
+    @InjectMocks UserFcmTokenService userFcmTokenService;
+
+    @Mock UserFcmTokenRepository userFcmTokenRepository;
+
+    private User user(String phone) {
+        return User.builder().phone(phone).password("pw").role(Role.GUARDIAN).build();
+    }
+
+    private UserFcmToken token(User user, String tokenValue) {
+        UserFcmToken t = UserFcmToken.builder().user(user).token(tokenValue).build();
+        ReflectionTestUtils.setField(t, "id", 1L);
+        return t;
+    }
+
+    @Test
+    void saveToken_신규토큰_저장() {
+        User user = user("01011111111");
+        given(userFcmTokenRepository.existsByUserAndToken(user, "new-token")).willReturn(false);
+
+        userFcmTokenService.saveToken(user, "new-token");
+
+        ArgumentCaptor<UserFcmToken> captor = ArgumentCaptor.forClass(UserFcmToken.class);
+        verify(userFcmTokenRepository).save(captor.capture());
+        assertThat(captor.getValue().getToken()).isEqualTo("new-token");
+        assertThat(captor.getValue().getUser()).isEqualTo(user);
+    }
+
+    @Test
+    void saveToken_중복토큰_저장스킵() {
+        User user = user("01011111111");
+        given(userFcmTokenRepository.existsByUserAndToken(user, "existing-token")).willReturn(true);
+
+        userFcmTokenService.saveToken(user, "existing-token");
+
+        verify(userFcmTokenRepository, never()).save(any());
+    }
+
+    @Test
+    void getTokensByUser_토큰목록반환() {
+        User user = user("01011111111");
+        given(userFcmTokenRepository.findAllByUser(user))
+                .willReturn(List.of(token(user, "token-a"), token(user, "token-b")));
+
+        List<String> tokens = userFcmTokenService.getTokensByUser(user);
+
+        assertThat(tokens).containsExactly("token-a", "token-b");
+    }
+
+    @Test
+    void getTokensByUser_토큰없음_빈목록반환() {
+        User user = user("01011111111");
+        given(userFcmTokenRepository.findAllByUser(user)).willReturn(List.of());
+
+        List<String> tokens = userFcmTokenService.getTokensByUser(user);
+
+        assertThat(tokens).isEmpty();
+    }
+
+    @Test
+    void deleteAllByUser_유저토큰전체삭제() {
+        User user = user("01011111111");
+
+        userFcmTokenService.deleteAllByUser(user);
+
+        verify(userFcmTokenRepository).deleteAllByUser(user);
+    }
+}


### PR DESCRIPTION
## Summary

- `users` 테이블의 `fcm_token` 컬럼을 별도 `user_fcm_tokens` 테이블로 분리하여 다중 디바이스 FCM 토큰 지원
- 동일 토큰 중복 등록 방지 (upsert 처리)
- 알림 발송 시 유저의 모든 토큰에 전송
- 로그아웃/회원탈퇴 시 해당 유저의 전체 토큰 삭제

## Changes

- `UserFcmToken` 엔티티, `UserFcmTokenRepository`, `UserFcmTokenService` 신규 생성
- `User` 엔티티에서 `fcmToken` 필드 및 관련 메서드(`updateFcmToken`, `clearFcmToken`) 제거
- `NotificationService`: `UserFcmTokenService`로 토큰 조회, 전체 토큰에 알림 발송
- `AuthService`: 로그아웃 시 `UserFcmTokenService.deleteAllByUser` 호출
- `UserController`: `PATCH /device-token` → `UserFcmTokenService.saveToken` 호출
- `UserFcmTokenService` 단위 테스트 추가 (5개)
- `NotificationServiceTest` 업데이트

## Test plan

- [x] `./gradlew clean build` 통과
- [x] `UserFcmTokenServiceTest` — 신규토큰 저장, 중복토큰 스킵, 목록 조회, 빈 목록, 전체 삭제
- [x] `NotificationServiceTest` — FCM 토큰 있음/없음, 알림 발송 조건 전체 케이스
- [x] `UserControllerTest` — 인증/비인증 요청 응답 코드 검증

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)