### PR TITLE
#90 MySQL 외부 포트 3306 노출 (DataGrip 연결 지원)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     container_name: duty-checker-mysql
     networks:
       - traefik-net
+    ports:
+      - "3306:3306"
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}


### PR DESCRIPTION
## Summary
- `docker-compose.yml`의 mysql 서비스에 `ports: - "3306:3306"` 추가
- 기존에는 포트 노출이 없어 외부 클라이언트(DataGrip 등)에서 DB 접근 불가

## Test plan
- [ ] `docker compose down && docker compose up -d` 후 DataGrip에서 서버 IP:3306으로 연결 확인

Closes #90