### PR TITLE
#92 MySQL 외부 포트 3307로 변경 (호스트 포트 충돌 해결)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     networks:
       - traefik-net
     ports:
-      - "3306:3306"
+      - "3307:3306"
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}


### PR DESCRIPTION
## Summary
- mysql 서비스 포트 `3306:3306` → `3307:3306` 변경
- 호스트에 3306이 이미 사용 중이어서 컨테이너 기동 실패하던 문제 해결

## Test plan
- [ ] `docker compose up -d` 후 MySQL 컨테이너 정상 기동 확인
- [ ] DataGrip에서 `서버IP:3307`로 연결 확인

Closes #92