### PR TITLE
#94 User.phone 컬럼 length 수정 (회원탈퇴 Data truncation 해결)

### DIFF
--- a/src/main/java/com/guegue/duty_checker/user/domain/User.java
+++ b/src/main/java/com/guegue/duty_checker/user/domain/User.java
@@ -18,7 +18,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true, nullable = false, length = 20)
+    @Column(unique = true, nullable = false, length = 50)
     private String phone;
 
     @Column(nullable = false)


### PR DESCRIPTION
## Summary
- `User.phone` 컬럼 `length = 20` → `length = 50` 으로 변경
- 회원탈퇴 시 phone을 `"deleted_" + millis(13자) + "_" + phone(최대 20자)` = 최대 41자로 변환하는데 기존 20자 제한으로 Data truncation 에러 발생하던 문제 해결

## DB 마이그레이션
머지 후 운영 DB에 아래 쿼리 직접 실행 필요:
\`\`\`sql
ALTER TABLE users MODIFY COLUMN phone VARCHAR(50) NOT NULL;
\`\`\`

## Test plan
- [x] 빌드 및 전체 테스트 통과
- [ ] 운영 DB ALTER 쿼리 실행 후 회원탈퇴 API 정상 동작 확인

Closes #94