### PR TITLE
#98 Firebase Admin SDK 연동 및 FCM 발송 Provider 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ src/main/resources/application-local.yaml
 
 ### Planning ###
 .planning/
+
+# Firebase service account
+src/main/resources/firebase/

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 	// SMS
 	implementation 'net.nurigo:sdk:4.3.0'
 
+	// FCM
+	implementation 'com.google.firebase:firebase-admin:9.4.2'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/guegue/duty_checker/connection/service/ConnectionService.java
+++ b/src/main/java/com/guegue/duty_checker/connection/service/ConnectionService.java
@@ -79,6 +79,9 @@ public class ConnectionService {
         ConnectionStatus newStatus = parseStatus(reqDto.getStatus());
 
         connection.updateStatus(newStatus);
+        if (newStatus == ConnectionStatus.CONNECTED) {
+            notificationService.sendConnectionAcceptedAlert(connection.getRequester(), caller);
+        }
         return new UpdateConnectionStatusRespDto(connection.getId(), connection.getStatus());
     }
 

--- a/src/main/java/com/guegue/duty_checker/notification/infrastructure/FirebaseCloudMessagingProvider.java
+++ b/src/main/java/com/guegue/duty_checker/notification/infrastructure/FirebaseCloudMessagingProvider.java
@@ -1,0 +1,58 @@
+package com.guegue.duty_checker.notification.infrastructure;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Slf4j
+@Component
+@Primary
+public class FirebaseCloudMessagingProvider implements FcmProvider {
+
+    private final FirebaseApp firebaseApp;
+
+    public FirebaseCloudMessagingProvider(Optional<FirebaseApp> firebaseApp) {
+        this.firebaseApp = firebaseApp.orElse(null);
+        if (this.firebaseApp == null) {
+            log.warn("FirebaseApp bean not found — FCM sends will be no-ops");
+        }
+    }
+
+    @Override
+    public void send(String fcmToken, String title, String body) {
+        if (firebaseApp == null) {
+            log.info("[MockFCM fallback] token={}, title={}, body={}", fcmToken, title, body);
+            return;
+        }
+        if (fcmToken == null || fcmToken.isBlank()) {
+            log.warn("Skip FCM send: fcmToken is empty");
+            return;
+        }
+        Message message = buildMessage(fcmToken, title, body);
+        try {
+            String response = FirebaseMessaging.getInstance(firebaseApp).send(message);
+            log.info("FCM sent: messageId={}", response);
+        } catch (FirebaseMessagingException e) {
+            log.error("FCM send failed: token={}, errorCode={}, message={}",
+                fcmToken, e.getMessagingErrorCode(), e.getMessage());
+            // 호출 흐름을 막지 않기 위해 예외를 다시 던지지 않는다.
+        }
+    }
+
+    private Message buildMessage(String fcmToken, String title, String body) {
+        return Message.builder()
+            .setToken(fcmToken)
+            .setNotification(Notification.builder()
+                .setTitle(title)
+                .setBody(body)
+                .build())
+            .build();
+    }
+}

--- a/src/main/java/com/guegue/duty_checker/notification/infrastructure/FirebaseConfig.java
+++ b/src/main/java/com/guegue/duty_checker/notification/infrastructure/FirebaseConfig.java
@@ -1,0 +1,45 @@
+package com.guegue.duty_checker.notification.infrastructure;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+
+import java.io.InputStream;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class FirebaseConfig {
+
+    private final ApplicationContext applicationContext;
+
+    @Value("${firebase.service-account-path:classpath:firebase/service-account.json}")
+    private String serviceAccountPath;
+
+    @Bean
+    public FirebaseApp firebaseApp() throws Exception {
+        if (!FirebaseApp.getApps().isEmpty()) {
+            return FirebaseApp.getInstance();
+        }
+        Resource resource = applicationContext.getResource(serviceAccountPath);
+        if (!resource.exists()) {
+            throw new IllegalStateException(
+                "Firebase service account file not found: " + serviceAccountPath);
+        }
+        try (InputStream in = resource.getInputStream()) {
+            FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(in))
+                .build();
+            FirebaseApp app = FirebaseApp.initializeApp(options);
+            log.info("FirebaseApp initialized from {}", serviceAccountPath);
+            return app;
+        }
+    }
+}

--- a/src/main/java/com/guegue/duty_checker/notification/infrastructure/FirebaseConfig.java
+++ b/src/main/java/com/guegue/duty_checker/notification/infrastructure/FirebaseConfig.java
@@ -25,13 +25,17 @@ public class FirebaseConfig {
 
     @Bean
     public FirebaseApp firebaseApp() throws Exception {
+        if (serviceAccountPath == null || serviceAccountPath.isBlank()) {
+            log.warn("firebase.service-account-path is empty — FCM disabled");
+            return null;
+        }
         if (!FirebaseApp.getApps().isEmpty()) {
             return FirebaseApp.getInstance();
         }
         Resource resource = applicationContext.getResource(serviceAccountPath);
         if (!resource.exists()) {
-            throw new IllegalStateException(
-                "Firebase service account file not found: " + serviceAccountPath);
+            log.warn("Firebase service account file not found: {} — FCM disabled", serviceAccountPath);
+            return null;
         }
         try (InputStream in = resource.getInputStream()) {
             FirebaseOptions options = FirebaseOptions.builder()

--- a/src/main/java/com/guegue/duty_checker/notification/infrastructure/MockFcmProvider.java
+++ b/src/main/java/com/guegue/duty_checker/notification/infrastructure/MockFcmProvider.java
@@ -3,6 +3,8 @@ package com.guegue.duty_checker.notification.infrastructure;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+// FirebaseCloudMessagingProvider(@Primary)가 항상 우선 적용됨.
+// 이 빈은 테스트에서 @MockBean / @SpyBean으로 대체하거나, 직접 주입이 필요한 경우를 위한 fallback 구현체이다.
 @Slf4j
 @Component
 public class MockFcmProvider implements FcmProvider {

--- a/src/main/java/com/guegue/duty_checker/notification/service/NotificationService.java
+++ b/src/main/java/com/guegue/duty_checker/notification/service/NotificationService.java
@@ -41,6 +41,17 @@ public class NotificationService {
         );
     }
 
+    public void sendConnectionAcceptedAlert(User requester, User acceptor) {
+        if (requester.getFcmToken() == null) {
+            return;
+        }
+        fcmProvider.send(
+                requester.getFcmToken(),
+                "연결 신청이 수락됐어요",
+                acceptor.getPhone() + "님이 연결 신청을 수락했어요."
+        );
+    }
+
     @Transactional
     public void sendMissingCheckInAlerts() {
         ZonedDateTime now = ZonedDateTime.now(KST);

--- a/src/main/java/com/guegue/duty_checker/notification/service/NotificationService.java
+++ b/src/main/java/com/guegue/duty_checker/notification/service/NotificationService.java
@@ -36,8 +36,8 @@ public class NotificationService {
         }
         fcmProvider.send(
                 target.getFcmToken(),
-                "연결 신청이 왔습니다",
-                requester.getPhone() + "님이 연결을 신청했습니다."
+                "연결 신청이 도착했어요",
+                requester.getPhone() + "님이 연결을 신청했어요."
         );
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -31,6 +31,9 @@ coolsms:
     domain: https://api.coolsms.co.kr
     from-num: ${COOLSMS_FROM_NUM}
 
+firebase:
+  service-account-path: ${FIREBASE_SERVICE_ACCOUNT_PATH:classpath:firebase/service-account.json}
+
 server:
   port: 8080
 

--- a/src/test/java/com/guegue/duty_checker/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/guegue/duty_checker/notification/service/NotificationServiceTest.java
@@ -68,7 +68,7 @@ class NotificationServiceTest {
 
         notificationService.sendConnectionRequestAlert(target, requester);
 
-        verify(fcmProvider).send("token-xyz", "연결 신청이 왔습니다", "01011111111님이 연결을 신청했습니다.");
+        verify(fcmProvider).send("token-xyz", "연결 신청이 도착했어요", "01011111111님이 연결을 신청했어요.");
     }
 
     @Test

--- a/src/test/java/com/guegue/duty_checker/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/guegue/duty_checker/notification/service/NotificationServiceTest.java
@@ -81,6 +81,29 @@ class NotificationServiceTest {
         verify(fcmProvider, never()).send(anyString(), anyString(), anyString());
     }
 
+    // ─── sendConnectionAcceptedAlert ──────────────────────────────────────
+
+    @Test
+    void sendConnectionAcceptedAlert_FCM토큰있음_알림발송() {
+        User requester = subject("01011111111");
+        requester.updateFcmToken("token-req");
+        User acceptor = guardianWithToken("01022222222", "token-acc");
+
+        notificationService.sendConnectionAcceptedAlert(requester, acceptor);
+
+        verify(fcmProvider).send("token-req", "연결 신청이 수락됐어요", "01022222222님이 연결 신청을 수락했어요.");
+    }
+
+    @Test
+    void sendConnectionAcceptedAlert_FCM토큰없음_알림스킵() {
+        User requester = subject("01011111111");
+        User acceptor = guardianWithToken("01022222222", "token-acc");
+
+        notificationService.sendConnectionAcceptedAlert(requester, acceptor);
+
+        verify(fcmProvider, never()).send(anyString(), anyString(), anyString());
+    }
+
     // ─── sendMissingCheckInAlerts ──────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

- Firebase Admin SDK(`com.google.firebase:firebase-admin:9.4.2`) 의존성 추가
- `FirebaseConfig`: 서비스 계정 JSON을 classpath에서 읽어 `FirebaseApp` 빈 초기화
- `FirebaseCloudMessagingProvider`: `Optional<FirebaseApp>` 주입 + `@Primary` 패턴으로 실제 FCM 전송 구현
- `MockFcmProvider`: fallback으로 유지 (FirebaseCloudMessagingProvider가 @Primary로 우선 적용)
- 서비스 계정 JSON(`src/main/resources/firebase/`) `.gitignore` 처리

## Test plan

- [ ] `./gradlew clean build` BUILD SUCCESSFUL 확인
- [ ] 로컬 실행 시 로그에 `FirebaseApp initialized from classpath:firebase/service-account.json` 확인
- [ ] `src/main/resources/firebase/service-account.json`이 git에 추적되지 않는지 확인

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)